### PR TITLE
Encode path segments in urls to prevent illegal uris

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,7 @@
 
 	<properties>
 		<slf4j.version>1.5.11</slf4j.version>
+		<encoding>UTF-8</encoding>
 	</properties>
 
 	<dependencies>

--- a/src/test/java/it/geosolutions/geoserver/rest/HTTPUtilsTest.java
+++ b/src/test/java/it/geosolutions/geoserver/rest/HTTPUtilsTest.java
@@ -1,0 +1,16 @@
+package it.geosolutions.geoserver.rest;
+
+import junit.framework.TestCase;
+
+public class HTTPUtilsTest extends TestCase {
+    public void testEncodeUrl() throws Exception {
+        assertEquals("http://with%20spaces", HTTPUtils.encodeUrl("http://with spaces"));
+        assertEquals("http://with%20spaces?p1=v1", HTTPUtils.encodeUrl("http://with spaces?p1=v1"));
+        assertEquals("http://without/spaces?p1=v1", HTTPUtils.encodeUrl("http://without/spaces?p1=v1"));
+        assertEquals("http://without/spaces", HTTPUtils.encodeUrl("http://without/spaces"));
+        assertEquals("http://without/spaces#fragment", HTTPUtils.encodeUrl("http://without/spaces#fragment"));
+        assertEquals("http://without/spaces?p1=v1#fragment", HTTPUtils.encodeUrl("http://without/spaces?p1=v1#fragment"));
+        assertEquals("http://with%20spaces#fragment", HTTPUtils.encodeUrl("http://with spaces#fragment"));
+        assertEquals("brokenurl?p1=v1", HTTPUtils.encodeUrl("brokenurl?p1=v1"));
+    }
+}


### PR DESCRIPTION
I have a geoserver instance where users can publish layers to the geoserver.  Because there are so many users that can publish to the geoserver we have been unable to prevent them from publishing layers with spaces in the names.  When there are spaces (or other certain characters), the rest api
is broken because the urls have spaces in them.

Obviously the best solution is to fix Geoserver so that a layer with a space in the name (or in the workspace name) does not break the REST API.  However that is a substantial amount of work and this change makes this library more robust in the face or inconsiderate geoserver
administrators so I decided to make the change here.  When I have time I would like to patch Geoserver as well but that is another issue.

The fix I have made is quite simple.  In HttpUtils I separate each url into its path segments and encode each segment then put the url back together again.  Because of this all urls will work regardless of the workspace or layer name.
