### PR TITLE
#127 fix: expose the layers styles list to the java api

### DIFF
--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/RESTLayer.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/RESTLayer.java
@@ -53,6 +53,12 @@ import org.jdom.Namespace;
         <name>capitals</name>
         <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/styles/capitals.xml" type="application/xml"/>
     </defaultStyle>
+    <styles class="linked-hash-set">
+    	<style>
+      		<name>green</name>
+      		<atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/styles/green.xml" type="application/xml"/>
+    	</style>
+  	</styles>
     <resource class="featureType">
         <name>tasmania_cities</name>
         <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/workspaces/topp/datastores/taz_shapes/featuretypes/tasmania_cities.xml" type="application/xml"/>
@@ -149,6 +155,15 @@ public class RESTLayer {
 		Element defaultStyle = layerElem.getChild("defaultStyle");
 		return defaultStyle == null? null : defaultStyle.getChildText("name");
   	}
+	
+	public RESTStyleList getStyles() {
+		RESTStyleList styleList = null;
+		final Element stylesRoot = layerElem.getChild("styles");
+		if (stylesRoot != null) {
+			styleList = new RESTStyleList(stylesRoot);
+		}
+		return styleList;
+	}
 
 	public String getDefaultStyleWorkspace() {
 		Element defaultStyle = layerElem.getChild("defaultStyle");

--- a/src/test/java/it/geosolutions/geoserver/decoder/LayerDecoderTest.java
+++ b/src/test/java/it/geosolutions/geoserver/decoder/LayerDecoderTest.java
@@ -1,6 +1,7 @@
 package it.geosolutions.geoserver.decoder;
 
 import it.geosolutions.geoserver.rest.decoder.RESTLayer;
+import it.geosolutions.geoserver.rest.decoder.RESTStyleList;
 import it.geosolutions.geoserver.rest.encoder.authorityurl.GSAuthorityURLInfoEncoder;
 import it.geosolutions.geoserver.rest.encoder.identifier.GSIdentifierInfoEncoder;
 
@@ -65,6 +66,14 @@ public class LayerDecoderTest {
 	public void testDefaultStyle() {
 		Assert.assertEquals("capitals", layer.getDefaultStyle());
   	}
+	
+	@Test
+	public void testStyles() {
+		RESTStyleList styles = layer.getStyles();
+		Assert.assertTrue(styles.size() == 2);
+		Assert.assertEquals("green", styles.get(0).getName());
+		Assert.assertEquals("blue", styles.get(1).getName());
+	}
 	
 	@Test
 	public void testResourceUrl() {

--- a/src/test/resources/testdata/layerExample.xml
+++ b/src/test/resources/testdata/layerExample.xml
@@ -6,6 +6,16 @@
         <name>capitals</name>
         <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/styles/capitals.xml" type="application/xml"/>
     </defaultStyle>
+    <styles class="linked-hash-set">
+    	<style>
+    		<name>green</name>
+    		<atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/styles/green.xml" type="application/xml"/>
+    	</style>
+    	<style>
+    		<name>blue</name>
+    		<atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/styles/blue.xml" type="application/xml"/>
+    	</style>
+    </styles>
     <resource class="featureType">
         <name>tasmania_cities</name>
         <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/workspaces/topp/datastores/taz_shapes/featuretypes/tasmania_cities.xml" type="application/xml"/>


### PR DESCRIPTION
The alternative styles of a RESTLayer are currently not accessible by the java api.
