### PR TITLE
#129 fix: create RESTBoundingBox class and wrap latLonBoundingBox and nativeBoundingBox attributes

### DIFF
--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/RESTBoundingBox.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/RESTBoundingBox.java
@@ -1,0 +1,48 @@
+package it.geosolutions.geoserver.rest.decoder;
+
+import org.jdom.Element;
+
+/**
+ * Parse a Boundingbox of the following structure
+ * 
+ * <minx>472800.0</minx>
+ * <maxx>817362.0</maxx>
+ * <miny>35053.40625</miny>
+ * <maxy>301500.0</maxy>
+ * <crs class="projected">EPSG:21781</crs>
+ * 
+ * @author nmandery
+ */
+public class RESTBoundingBox {
+
+	protected Element bboxElem;
+	
+	public RESTBoundingBox(Element bboxElem) {
+		this.bboxElem = bboxElem;
+	}
+	
+	public String getCRS() {
+		return this.bboxElem.getChildText("crs");
+	}
+	
+	protected double getEdge(String edge) {
+		return Double.parseDouble(this.bboxElem.getChildText(edge));
+	}
+
+	public double getMinX() {
+		return this.getEdge("minx");
+	}
+	
+	public double getMaxX() {
+		return this.getEdge("maxx");
+	}
+
+	public double getMinY() {
+		return this.getEdge("miny");
+	}
+
+	public double getMaxY() {
+		return this.getEdge("maxy");
+	}
+
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/RESTResource.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/RESTResource.java
@@ -109,31 +109,44 @@ public class RESTResource {
                 Namespace.getNamespace("atom", "http://www.w3.org/2005/Atom"));
         return atom.getAttributeValue("href");
     }
+    
+	public RESTBoundingBox getNativeBoundingBox() {
+		RESTBoundingBox bbox = null;
+		Element bboxElement = rootElem.getChild("nativeBoundingBox");
+		if (bboxElement != null) {
+			bbox = new RESTBoundingBox(bboxElement);
+		}
+		return bbox;
+	}
+	
+	public RESTBoundingBox getLatLonBoundingBox() {
+		RESTBoundingBox bbox = null;
+		Element bboxElement = rootElem.getChild("latLonBoundingBox");
+		if (bboxElement != null) {
+			bbox = new RESTBoundingBox(bboxElement);
+		}
+		return bbox;
+	}
 
     public String getCRS() {
-        Element elBBox = rootElem.getChild("latLonBoundingBox");
-        return elBBox.getChildText("crs");
-    }
-
-    protected double getLatLonEdge(String edge) {
-        Element elBBox = rootElem.getChild("latLonBoundingBox");
-        return Double.parseDouble(elBBox.getChildText(edge));
+    	RESTBoundingBox bbox = this.getLatLonBoundingBox();
+    	return bbox.getCRS();
     }
 
     public double getMinX() {
-        return getLatLonEdge("minx");
+        return this.getLatLonBoundingBox().getMinX();
     }
 
     public double getMaxX() {
-        return getLatLonEdge("maxx");
+    	return this.getLatLonBoundingBox().getMaxX();
     }
 
     public double getMinY() {
-        return getLatLonEdge("miny");
+    	return this.getLatLonBoundingBox().getMinY();
     }
 
     public double getMaxY() {
-        return getLatLonEdge("maxy");
+    	return this.getLatLonBoundingBox().getMaxY();
     }
 
     /**

--- a/src/test/java/it/geosolutions/geoserver/decoder/ResourceDecoderTest.java
+++ b/src/test/java/it/geosolutions/geoserver/decoder/ResourceDecoderTest.java
@@ -1,5 +1,6 @@
 package it.geosolutions.geoserver.decoder;
 
+import it.geosolutions.geoserver.rest.decoder.RESTBoundingBox;
 import it.geosolutions.geoserver.rest.decoder.RESTCoverage;
 import it.geosolutions.geoserver.rest.encoder.dimensions.GSCoverageDimensionEncoder;
 import it.geosolutions.geoserver.rest.encoder.metadatalink.GSMetadataLinkInfoEncoder;
@@ -94,6 +95,28 @@ public class ResourceDecoderTest {
         Assert.assertEquals(coverage.getMaxY(), 90, 0);
     }
 
+    @Test
+    public void testLatLonBoundingBox() {
+    	RESTBoundingBox bbox = coverage.getLatLonBoundingBox();
+    	Assert.assertTrue(bbox != null);
+    	Assert.assertEquals("EPSG:4326", bbox.getCRS());
+        Assert.assertEquals(-180.0, bbox.getMinX(), 0);
+        Assert.assertEquals(180.0, bbox.getMaxX(), 0);
+        Assert.assertEquals(-90, bbox.getMinY(), 0);
+        Assert.assertEquals(90, bbox.getMaxY(), 0); 	
+    }
+    
+    @Test
+    public void testNativeBoundingBox() {
+    	RESTBoundingBox bbox = coverage.getNativeBoundingBox();
+    	Assert.assertTrue(bbox != null);
+    	Assert.assertEquals("EPSG:4326", bbox.getCRS());
+        Assert.assertEquals(-180.0, bbox.getMinX(), 0);
+        Assert.assertEquals(180.0, bbox.getMaxX(), 0);
+        Assert.assertEquals(-90, bbox.getMinY(), 0);
+        Assert.assertEquals(90, bbox.getMaxY(), 0); 	
+    }
+    
     @Test
     public void testMetadataLinkInfo() throws IOException {
 


### PR DESCRIPTION
The current implementation only gives access to the LatLonBoundingBox while there is not possibility to read the NativeBoundingBox
