### PR TITLE
Added methods to update and publish SLD V1.1.0 using REST API

### DIFF
--- a/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTPublisher.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTPublisher.java
@@ -372,6 +372,21 @@ public class GeoServerRESTPublisher {
     /**
      * Update a Style.
      * 
+     * @param sldFile the File containing the SLD document.
+     * @param name the Style name.
+     * @param raw the raw format
+     * 
+     * @return <TT>true</TT> if the operation completed successfully.
+     * @throws IllegalArgumentException if the sldFile file or name are null or name is empty.
+     */
+    public boolean updateStyle(final File sldFile, final String name, boolean raw)
+            throws IllegalArgumentException {
+        return styleManager.updateStyle(sldFile, name, raw);
+    }
+
+    /**
+     * Update a Style.
+     * 
      * @param sldBody the new SLD document as a String.
      * @param name the Style name to update.
      * 

--- a/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTPublisher.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTPublisher.java
@@ -359,6 +359,19 @@ public class GeoServerRESTPublisher {
     /**
      * Store and publish a Style, assigning it a name and choosing the raw format.
      *
+     * @param sldBody the full SLD document as a String.
+     * @param name the Style name.
+     * @param raw the raw format
+     *
+     * @return <TT>true</TT> if the operation completed successfully.
+     */
+    public boolean publishStyle(String sldBody, String name, boolean raw) {
+        return styleManager.publishStyle(sldBody, name, raw);
+    }
+    
+    /**
+     * Store and publish a Style, assigning it a name and choosing the raw format.
+     *
      * @param sldFile the File containing the SLD document.
      * @param name the Style name.
      * @param raw the raw format
@@ -377,11 +390,26 @@ public class GeoServerRESTPublisher {
      * @param raw the raw format
      * 
      * @return <TT>true</TT> if the operation completed successfully.
-     * @throws IllegalArgumentException if the sldFile file or name are null or name is empty.
+     * @throws IllegalArgumentException if the style body or name are null or empty.
      */
     public boolean updateStyle(final File sldFile, final String name, boolean raw)
             throws IllegalArgumentException {
         return styleManager.updateStyle(sldFile, name, raw);
+    }
+    
+    /**
+     * Update a Style.
+     * 
+     * @param sldBody the new SLD document as a String.
+     * @param name the Style name.
+     * @param raw the raw format
+     * 
+     * @return <TT>true</TT> if the operation completed successfully.
+     * @throws IllegalArgumentException if the style body or name are null or empty.
+     */
+    public boolean updateStyle(final String sldBody, final String name, boolean raw)
+            throws IllegalArgumentException {
+        return styleManager.updateStyle(sldBody, name, raw);
     }
 
     /**

--- a/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTPublisher.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTPublisher.java
@@ -1353,7 +1353,7 @@ public class GeoServerRESTPublisher {
      * </ul>
      */
     public enum Format {
-        XML, JSON, HTML, SLD;
+        XML, JSON, HTML, SLD, SLD_1_1_0;
 
         /**
          * Gets the mime type from a format.
@@ -1371,6 +1371,8 @@ public class GeoServerRESTPublisher {
                 return "application/json";
             case SLD:
                 return "application/vnd.ogc.sld+xml";
+            case SLD_1_1_0:
+                return "application/vnd.ogc.se+xml";
             default:
                 return null;
             }

--- a/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTPublisher.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTPublisher.java
@@ -357,6 +357,19 @@ public class GeoServerRESTPublisher {
     }
 
     /**
+     * Store and publish a Style, assigning it a name and choosing the raw format.
+     *
+     * @param sldFile the File containing the SLD document.
+     * @param name the Style name.
+     * @param raw the raw format
+     *
+     * @return <TT>true</TT> if the operation completed successfully.
+     */
+    public boolean publishStyle(File sldFile, String name, boolean raw) {
+        return styleManager.publishStyle(sldFile, name, raw);
+    }
+
+    /**
      * Update a Style.
      * 
      * @param sldBody the new SLD document as a String.

--- a/src/main/java/it/geosolutions/geoserver/rest/manager/GeoServerRESTStyleManager.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/manager/GeoServerRESTStyleManager.java
@@ -260,6 +260,15 @@ public class GeoServerRESTStyleManager extends GeoServerRESTAbstractManager {
         return result != null;
     }
     
+    /**
+     * Store and publish a Style, assigning it a name and choosing the raw format.
+     *
+     * @param sldFile the File containing the SLD document.
+     * @param name the Style name.
+     * @param raw the raw format
+     *
+     * @return <TT>true</TT> if the operation completed successfully.
+     */
     public boolean publishStyle(final File sldFile, final String name, final boolean raw) {
         /*
          * This is the equivalent call with cUrl:

--- a/src/main/java/it/geosolutions/geoserver/rest/manager/GeoServerRESTStyleManager.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/manager/GeoServerRESTStyleManager.java
@@ -286,7 +286,7 @@ public class GeoServerRESTStyleManager extends GeoServerRESTAbstractManager {
          * This is the equivalent call with cUrl:
          *
          * {@code curl -u admin:geoserver -XPOST \ -H 'Content-type: application/vnd.ogc.sld+xml' \ -d @$FULLSLD \
-         * http://$GSIP:$GSPORT/$SERVLET/rest/styles?name=name&raw=raw}
+         * http://$GSIP:$GSPORT/$SERVLET/rest/styles?name=$name&raw=$raw}
          */
         String sUrl = buildPostUrl(null, name);
         sUrl += "&raw=" + raw;
@@ -296,6 +296,41 @@ public class GeoServerRESTStyleManager extends GeoServerRESTAbstractManager {
             contentType = GeoServerRESTPublisher.Format.SLD_1_1_0.getContentType();
         }
         String result = HTTPUtils.post(sUrl, sldFile, contentType, gsuser, gspass);
+        return result != null;
+    }
+    
+    /**
+     * Update a Style.
+     * 
+     * @param sldFile the File containing the SLD document.
+     * @param name the Style name.
+     * @param raw the raw format
+     * 
+     * @return <TT>true</TT> if the operation completed successfully.
+     * @throws IllegalArgumentException if the sldFile file or name are null or name is empty.
+     */
+    public boolean updateStyle(final File sldFile, final String name, final boolean raw) 
+            throws IllegalArgumentException {
+        /*
+         * This is the equivalent call with cUrl:
+         *
+         * {@code curl -u admin:geoserver -XPUT \ -H 'Content-type: application/vnd.ogc.sld+xml' \ -d @$FULLSLD \
+         * http://$GSIP:$GSPORT/$SERVLET/rest/styles?name=$name&raw=$raw}
+         */
+        if (sldFile == null) {
+            throw new IllegalArgumentException("Unable to updateStyle using a null parameter file");
+        } else if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("The style name may not be null or empty");
+        }
+        
+        String sUrl = buildUrl(null, name, null);
+        sUrl += "&raw=" + raw;
+        LOGGER.debug("POSTing new style " + name + " to " + sUrl);
+        String contentType = GeoServerRESTPublisher.Format.SLD.getContentType();
+        if(!this.checkSLD10Version(sldFile)){
+            contentType = GeoServerRESTPublisher.Format.SLD_1_1_0.getContentType();
+        }
+        String result = HTTPUtils.put(sUrl, sldFile, contentType, gsuser, gspass);
         return result != null;
     }
 

--- a/src/main/java/it/geosolutions/geoserver/rest/manager/GeoServerRESTStyleManager.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/manager/GeoServerRESTStyleManager.java
@@ -29,10 +29,13 @@ import it.geosolutions.geoserver.rest.HTTPUtils;
 import it.geosolutions.geoserver.rest.Util;
 import it.geosolutions.geoserver.rest.decoder.RESTStyle;
 import it.geosolutions.geoserver.rest.decoder.RESTStyleList;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -742,7 +745,8 @@ public class GeoServerRESTStyleManager extends GeoServerRESTAbstractManager {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         try {
             DocumentBuilder builder = factory.newDocumentBuilder();
-            Document doc = builder.parse(sldBody);
+            InputStream stream = new ByteArrayInputStream(sldBody.getBytes(StandardCharsets.UTF_8));
+            Document doc = builder.parse(stream);
             result = this.checkSLD10Version(doc);
         } catch (SAXException ex) {
             LOGGER.error("Error parsing SLD file: " + ex);

--- a/src/main/java/it/geosolutions/geoserver/rest/manager/GeoServerRESTStyleManager.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/manager/GeoServerRESTStyleManager.java
@@ -259,6 +259,20 @@ public class GeoServerRESTStyleManager extends GeoServerRESTAbstractManager {
         String result = HTTPUtils.post(sUrl, sldFile, GeoServerRESTPublisher.Format.SLD.getContentType(), gsuser, gspass);
         return result != null;
     }
+    
+    public boolean publishStyle(final File sldFile, final String name, final boolean raw) {
+        /*
+         * This is the equivalent call with cUrl:
+         *
+         * {@code curl -u admin:geoserver -XPOST \ -H 'Content-type: application/vnd.ogc.sld+xml' \ -d @$FULLSLD \
+         * http://$GSIP:$GSPORT/$SERVLET/rest/styles?name=name&raw=raw}
+         */
+        String sUrl = buildPostUrl(null, name);
+        sUrl += "&raw=" + raw;
+        LOGGER.debug("POSTing new style " + name + " to " + sUrl);
+        String result = HTTPUtils.post(sUrl, sldFile, GeoServerRESTPublisher.Format.SLD.getContentType(), gsuser, gspass);
+        return result != null;
+    }
 
     /**
      * Update a Style.

--- a/src/test/java/it/geosolutions/geoserver/rest/publisher/GeoserverRESTStyleTest.java
+++ b/src/test/java/it/geosolutions/geoserver/rest/publisher/GeoserverRESTStyleTest.java
@@ -78,6 +78,15 @@ public class GeoserverRESTStyleTest extends GeoserverRESTTest {
 
 		assertFalse(publisher.publishStyle(sldFile));
 		assertTrue(reader.existsStyle(STYLENAME));
+                
+		final String STYLENAMEV110 = "restteststyleV110";
+		File sldFileV110 = new ClassPathResource("testdata/" + STYLENAMEV110 + ".sld")
+				.getFile();
+
+                assertTrue(publisher.publishStyle(sldFileV110, STYLENAMEV110, true));
+		assertTrue(reader.existsStyle(STYLENAME));
+
+		assertFalse(publisher.publishStyle(sldFileV110, STYLENAMEV110, true));
 
         RESTStyle style = reader.getStyle(STYLENAME);
         assertEquals(STYLENAME, style.getName());
@@ -133,9 +142,14 @@ public class GeoserverRESTStyleTest extends GeoserverRESTTest {
 
 		File sldFile = new ClassPathResource("testdata/restteststyle.sld")
 				.getFile();
+                
+                final String STYLENAMEV110 = "restteststyleV110";
+		File sldFileV110 = new ClassPathResource("testdata/" + STYLENAMEV110 + ".sld")
+				.getFile();
 
 		// known state?
 		cleanupTestStyle(styleName);
+		cleanupTestStyle(STYLENAMEV110);
 
 		// test insert
 		boolean published = publisher.publishStyle(sldFile); // Will take the
@@ -152,6 +166,19 @@ public class GeoserverRESTStyleTest extends GeoserverRESTTest {
 		boolean ok = publisher.removeStyle(styleName);
 		assertTrue("Unpublish() failed", ok);
 		assertFalse(reader.existsStyle(styleName));
+		
+                published = publisher.publishStyle(sldFileV110, STYLENAMEV110, true);
+
+		assertTrue("publish() failed", published);
+		assertTrue(reader.existsStyle(STYLENAMEV110));
+
+		boolean updated = publisher.updateStyle(sldFileV110, STYLENAMEV110, true);
+		assertTrue("update() failed", updated);
+
+		// test delete
+		ok = publisher.removeStyle(STYLENAMEV110);
+		assertTrue("Unpublish() failed", ok);
+		assertFalse(reader.existsStyle(STYLENAMEV110));
 	}
 
 	@Test

--- a/src/test/resources/testdata/restteststyleV110.sld
+++ b/src/test/resources/testdata/restteststyleV110.sld
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld StyledLayerDescriptor.xsd">
+    <NamedLayer>
+        <se:Name>OCEANSEA_1M:Foundation</se:Name>
+        <UserStyle>
+            <se:Name>GEOSYM</se:Name>
+            <IsDefault>1</IsDefault>
+            <se:FeatureTypeStyle>
+                <se:FeatureTypeName>Foundation</se:FeatureTypeName>
+                <se:Rule>
+                    <se:Name>main</se:Name>
+                    <se:PolygonSymbolizer uom="http://www.opengis.net/sld/units/pixel">
+                        <se:Name>MySymbol</se:Name>
+                        <se:Description>
+                            <se:Title>Example Symbol</se:Title>
+                            <se:Abstract>This is just a simple example.</se:Abstract>
+                        </se:Description>
+                        <se:Geometry>
+                            <ogc:PropertyName>GEOMETRY</ogc:PropertyName>
+                        </se:Geometry>
+                        <se:Fill>
+                            <se:SvgParameter name="fill">#96C3F5</se:SvgParameter>
+                        </se:Fill>
+                    </se:PolygonSymbolizer>
+                </se:Rule>
+            </se:FeatureTypeStyle>
+        </UserStyle>
+    </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
Hi all,
actually the GeoServer REST API does not permit to publish SLD file having version 1.1.0 according to this JIRA GEOS-6568 (https://jira.codehaus.org/browse/GEOS-6568)
I wrote two methods to publish and update the styles v. 1.1.0 using GeoServer-Manager.
Using the raw format it is possibile to publish correctly an SLD file v. 1.1.0 via REST API.
I wrote also few line of code to test the two methods.
I hope that this pull request can be accepted, thanks in advance.