### PR TITLE
GeoWebCache REST API integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,12 @@
 	</properties>
 
 	<dependencies>
+            
+                <dependency>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                    <version>1.9.13</version>
+                </dependency>
 
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTManager.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTManager.java
@@ -49,6 +49,7 @@ public class GeoServerRESTManager extends GeoServerRESTAbstractManager {
 
     private final GeoServerRESTPublisher publisher;
     private final GeoServerRESTReader reader;
+    private final GeoWebCacheRESTManager geoWebCacheManager;
 
     private final GeoServerRESTStoreManager storeManager;
     private final GeoServerRESTStyleManager styleManager;
@@ -73,6 +74,11 @@ public class GeoServerRESTManager extends GeoServerRESTAbstractManager {
         // Internal publisher and reader, provide simple access methods.
         publisher = new GeoServerRESTPublisher(restURL.toString(), username, password);
         reader = new GeoServerRESTReader(restURL, username, password);
+        String gwcGeoServerURL = restURL.toString();
+        if(!restURL.toString().endsWith("/")){
+            gwcGeoServerURL += '/';
+        }
+        this.geoWebCacheManager = new GeoWebCacheRESTManager(gwcGeoServerURL + "gwc", username, password);
         structuredGridCoverageReader = new GeoServerRESTStructuredGridCoverageReaderManager(restURL, username, password);
         storeManager = new GeoServerRESTStoreManager(restURL, gsuser, gspass);
         styleManager = new GeoServerRESTStyleManager(restURL, gsuser, gspass);
@@ -84,6 +90,10 @@ public class GeoServerRESTManager extends GeoServerRESTAbstractManager {
 
     public GeoServerRESTReader getReader() {
         return reader;
+    }
+
+    public GeoWebCacheRESTManager getGeoWebCacheManager() {
+        return geoWebCacheManager;
     }
 
     public GeoServerRESTStoreManager getStoreManager() {

--- a/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTPublisher.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTPublisher.java
@@ -1393,10 +1393,12 @@ public class GeoServerRESTPublisher {
      * <li>JSON (application/json)</li>
      * <li>HTML (application/html)</li>
      * <li>SLD (application/vnd.ogc.sld+xml)</li>
+     * <li>SLD_1_1_0 (application/vnd.ogc.se+xml)</li>
+     * <li>TXT (text/xml)</li>
      * </ul>
      */
     public enum Format {
-        XML, JSON, HTML, SLD, SLD_1_1_0;
+        XML, JSON, HTML, SLD, SLD_1_1_0, TXT_XML;
 
         /**
          * Gets the mime type from a format.
@@ -1416,6 +1418,8 @@ public class GeoServerRESTPublisher {
                 return "application/vnd.ogc.sld+xml";
             case SLD_1_1_0:
                 return "application/vnd.ogc.se+xml";
+            case TXT_XML:
+                return "text/xml";
             default:
                 return null;
             }

--- a/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTReader.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTReader.java
@@ -1,7 +1,7 @@
 /*
  *  GeoServer-Manager - Simple Manager Library for GeoServer
  *  
- *  Copyright (C) 2007,2013 GeoSolutions S.A.S.
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
  *  http://www.geo-solutions.it
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/main/java/it/geosolutions/geoserver/rest/GeoWebCacheRESTManager.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/GeoWebCacheRESTManager.java
@@ -22,15 +22,29 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package it.geosolutions.geoserver.rest;
 
+import it.geosolutions.geoserver.rest.GeoServerRESTPublisher.Format;
+import it.geosolutions.geoserver.rest.decoder.RESTLayerList;
 import it.geosolutions.geoserver.rest.decoder.gwc.GWCRESTWMSLayer;
+import it.geosolutions.geoserver.rest.decoder.gwc.diskquota.GWCQuotaConfiguration;
+import it.geosolutions.geoserver.rest.decoder.gwc.diskquota.GWCQuotaConfigJSONWrapper;
+import it.geosolutions.geoserver.rest.decoder.gwc.masstruncate.MassTruncateRequests;
+import it.geosolutions.geoserver.rest.decoder.gwc.seed.GWCTruncateSeedType;
+import it.geosolutions.geoserver.rest.decoder.gwc.seed.GlobalSeedStatus;
+import it.geosolutions.geoserver.rest.decoder.gwc.statistics.GWCInMemoryCacheStatistics;
+import it.geosolutions.geoserver.rest.decoder.gwc.statistics.GWCInMemoryCacheStatisticsXML;
+import java.io.File;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.logging.Level;
+import org.apache.commons.httpclient.NameValuePair;
+import org.codehaus.jackson.map.JsonMappingException;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.SerializationConfig;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,27 +54,33 @@ import org.slf4j.LoggerFactory;
  */
 public class GeoWebCacheRESTManager {
 
-        private final static Logger LOGGER = LoggerFactory.getLogger(GeoWebCacheRESTManager.class);
-    
+    private final static Logger LOGGER = LoggerFactory.getLogger(GeoWebCacheRESTManager.class);
+    private ObjectMapper mapper = new ObjectMapper();
+
     /**
-     * GeoWebCache instance base URL. E.g.: <TT>http://localhost:8080/geowebcache</TT>.
+     * GeoWebCache instance base URL. E.g.:
+     * <TT>http://localhost:8080/geowebcache</TT>.
      */
     private final String restURL;
 
     /**
-     * GeoWebCache instance privileged username, with read & write permission on REST API
+     * GeoWebCache instance privileged username, with read & write permission on
+     * REST API
      */
     private final String gwcUser;
 
     /**
-     * GeoWebCache instance password for privileged username with r&w permission on REST API
+     * GeoWebCache instance password for privileged username with r&w permission
+     * on REST API
      */
     private final String gwcPass;
-    
+
     /**
-     * Creates a <TT>GeoWebCacheRESTManager</TT> to connect against a GeoWebCache instance with the given URL and user credentials.
-     * 
-     * @param restURL the base GeoWebCache URL (e.g.: <TT>http://localhost:8080/geowebcache</TT>)
+     * Creates a <TT>GeoWebCacheRESTManager</TT> to connect against a
+     * GeoWebCache instance with the given URL and user credentials.
+     *
+     * @param restURL the base GeoWebCache URL (e.g.:
+     * <TT>http://localhost:8080/geowebcache</TT>)
      * @param username auth credential
      * @param password auth credential
      */
@@ -69,22 +89,25 @@ public class GeoWebCacheRESTManager {
         this.gwcUser = username;
         this.gwcPass = password;
 
-        URL url = null;
         try {
-            url = new URL(restURL);
+            new URL(restURL);
         } catch (MalformedURLException ex) {
-            LOGGER.error("Bad URL: Calls to GeoWebCache are going to fail" , ex);
+            LOGGER.error("Bad URL: Calls to GeoWebCache are going to fail", ex);
         }
+        mapper.configure(SerializationConfig.Feature.WRITE_NULL_MAP_VALUES, false);
+        mapper.setSerializationInclusion(JsonSerialize.Inclusion.NON_NULL);
+//        mapper.setSerializationInclusion(JsonSerialize.Inclusion.NON_EMPTY);
     }
-    
+
     /**
      * Check if a GeoWebCache instance is running at the given URL.
      * <BR>
-     * Return <TT>true</TT> if the configured GeoWebCache is up and replies to REST requests.
+     * Return <TT>true</TT> if the configured GeoWebCache is up and replies to
+     * REST requests.
      * <BR>
      * Send a HTTP GET request to the configured URL.<BR>
-     * Return <TT>true</TT> if a HTTP 200 code (OK) is read from the HTTP response;
-     * any other response code, or connection error, will return a
+     * Return <TT>true</TT> if a HTTP 200 code (OK) is read from the HTTP
+     * response; any other response code, or connection error, will return a
      * <TT>false</TT> boolean.
      *
      * @return true if a GeoWebCache instance was found at the configured URL.
@@ -92,36 +115,562 @@ public class GeoWebCacheRESTManager {
     public boolean existGeoWebCache() {
         return HTTPUtils.httpPing(restURL + "/rest/", gwcUser, gwcPass);
     }
-    
+
+    // <editor-fold desc="/statistics" defaultstate="collapsed">
+    //==========================================================================
+    //=== STATISTICS
+    //==========================================================================
+    /**
+     * @return the in memory cache statistics if the blobstore used is an
+     * instance of MemoryBlobStore.
+     * @throws org.codehaus.jackson.map.JsonMappingException
+     */
+    public GWCInMemoryCacheStatistics getInMemoryCacheStatisticsJSON() throws JsonMappingException {
+        GWCInMemoryCacheStatistics inMemoryCacheStatistics = null;
+        String statistics = this.load("/rest/statistics.json");
+        if (!Util.isEmpty(statistics)) {
+            try {
+                inMemoryCacheStatistics = this.mapper.readValue(statistics, 
+                        GWCInMemoryCacheStatistics.class);
+            } catch (IOException ioe) {
+                LOGGER.error("Error parsing the statistics: " + ioe);
+                throw new JsonMappingException("Error parsing the statistics: " + ioe);
+            }
+        }
+        return inMemoryCacheStatistics;
+    }
+
+    public GWCInMemoryCacheStatisticsXML getInMemoryCacheStatisticsXML() throws JsonMappingException {
+        GWCInMemoryCacheStatisticsXML inMemoryCacheStatistics = null;
+        String statistics = this.load("/rest/statistics.xml");
+        if (!Util.isEmpty(statistics)) {
+            try {
+                inMemoryCacheStatistics = this.mapper.readValue(statistics, 
+                        GWCInMemoryCacheStatisticsXML.class);
+            } catch (IOException ioe) {
+                LOGGER.error("Error parsing the statistics: " + ioe);
+                throw new JsonMappingException("Error parsing the statistics: " + ioe);
+            }
+        }
+        return inMemoryCacheStatistics;
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="/diskquota" defaultstate="collapsed">
+    //==========================================================================
+    //=== DISKQUOTA
+    //==========================================================================
+    /**
+     * @param diskQuotaConfiguration the configuration to serve
+     * @return the operation result
+     * @throws org.codehaus.jackson.map.JsonMappingException
+     * @throws IllegalArgumentException if the layerName is null or empty.
+     */
+    public boolean changeDiskQuotaConfig(GWCQuotaConfiguration diskQuotaConfiguration)
+            throws JsonMappingException {
+        String result = null;
+        if (diskQuotaConfiguration == null) {
+            throw new IllegalArgumentException("The diskQuotaConfiguration must not be null or empty");
+        }
+        /*
+         * This is the equivalent call with cUrl:
+         *
+         * {@code curl -u geowebcache:secured -v -XGET
+         *  http://$GWCIP:$GWCPORT/$SERVLET/rest/diskquota.json}
+         */
+        try {
+            GWCQuotaConfigJSONWrapper wrapper = new GWCQuotaConfigJSONWrapper();
+            wrapper.setQuotaConfiguration(diskQuotaConfiguration);
+            String jsonDiskQuotaConfig = this.mapper.writeValueAsString(wrapper);
+            LOGGER.debug("Quota configuration json: " + jsonDiskQuotaConfig);
+            result = this.put("/rest/diskquota.json", jsonDiskQuotaConfig, Format.JSON);
+        } catch (IOException ioe) {
+            LOGGER.error("Error parsing the quota configuration: " + ioe);
+            throw new JsonMappingException("Error parsing the quota configuration: " + ioe);
+        }
+        return result != null;
+    }
+
+    /**
+     * @return a list of pending (scheduled) and running tasks for all the
+     * layers.
+     * @throws org.codehaus.jackson.map.JsonMappingException
+     * @throws IllegalArgumentException if the layerName is null or empty.
+     */
+    public GWCQuotaConfiguration getCurrentDiskQuotaConfig() throws JsonMappingException {
+        GWCQuotaConfiguration quotaConfiguration = null;
+        /*
+         * This is the equivalent call with cUrl:
+         *
+         * {@code curl -u geowebcache:secured -v -XGET
+         *  http://$GWCIP:$GWCPORT/$SERVLET/rest/diskquota.json}
+         */
+        String quotaConfigurationJSON = this.load("/rest/diskquota.json");
+        if (!Util.isEmpty(quotaConfigurationJSON)) {
+            try {
+                LOGGER.debug("Quota configuration json: " + quotaConfigurationJSON);
+                GWCQuotaConfigJSONWrapper quotaConfigJSONWrapper
+                        = this.mapper.readValue(quotaConfigurationJSON,
+                                GWCQuotaConfigJSONWrapper.class);
+                quotaConfiguration = quotaConfigJSONWrapper.getQuotaConfiguration();
+            } catch (IOException ioe) {
+                LOGGER.error("Error parsing the quota configuration: " + ioe);
+                throw new JsonMappingException("Error parsing the quota configuration: " + ioe);
+            }
+        }
+        return quotaConfiguration;
+    }
+
+    // </editor-fold>
+    // <editor-fold desc="/masstruncate" defaultstate="collapsed">
+    //==========================================================================
+    //=== MASSTRUNCATE: Mass truncation provides a mechanism for completely 
+    //=== clearing caches more conveniently than with the seeding system.
+    //==========================================================================
+    /**
+     * TruncateLayer will clear all caches associated with a named layer,
+     * including all permutations of gridset, parameter filter values, and image
+     * formats.
+     *
+     * @param layerName the layer name to truncate
+     * @return <TT>true</TT> if the operation completed successfully.
+     * @throws IllegalArgumentException if the layerName is null or empty.
+     */
+    public boolean truncateLayer(String layerName) {
+        /*
+         * This is the equivalent call with cUrl:
+         *
+         * {@code curl -v -u geowebcache:secured -H "Content-type: text/xml" 
+         * -d "<truncateLayer><layerName>topp:states</layerName></truncateLayer>"
+         *  "http://$GWCIP:$GWCPORT/$SERVLET/rest/masstruncate"}
+         */
+        if (Util.isEmpty(layerName)) {
+            throw new IllegalArgumentException("The layerName may not be null or empty");
+        }
+
+        StringBuilder truncateLayerRequestBuilder = new StringBuilder();
+        truncateLayerRequestBuilder.append("<truncateLayer><layerName>").
+                append(layerName).append("</layerName></truncateLayer>");
+
+        final String result = this.post("/rest/masstruncate",
+                truncateLayerRequestBuilder.toString(),
+                GeoServerRESTPublisher.Format.TXT_XML);
+        LOGGER.debug("Mass truncation result: " + result);
+        return result != null;
+    }
+
+    /**
+     * @return Return a list of mass truncate requests available
+     */
+    public MassTruncateRequests getMassTruncateReqAvailable() {
+        /*
+         * This is the equivalent call with cUrl:
+         *
+         * {@code curl -v -u geowebcache:secured -XGET -H "Content-type: text/xml"
+         *  "http://$GWCIP:$GWCPORT/$SERVLET/rest/masstruncate"}
+         */
+        final String result = this.load("/rest/masstruncate");
+        return MassTruncateRequests.build(result);
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="/seed" defaultstate="collapsed">
+    //==========================================================================
+    //=== SEED
+    //==========================================================================
+    /**
+     * Add a new seed request assigning it a name.
+     *
+     * @param seedRequestFile the SEED REQUEST file.
+     * @param seedRequestName the seed request name to use.<b>Note the the seed
+     * request name must match the name of the seed request in the xml
+     * representation.</b>
+     *
+     * @return <TT>true</TT> if the operation completed successfully.
+     * @throws IllegalArgumentException if the seedRequestFile or the
+     * seedRequestName are null or empty.
+     */
+    public boolean addSeedRequest(final File seedRequestFile, final String seedRequestName)
+            throws IllegalArgumentException {
+        /*
+         * This is the equivalent call with cUrl:
+         *
+         * {@code curl -v -u geowebcache:secured -XPUT -H "Content-type: text/xml" -d @seedRequestFile.xml  
+         * "http://$GWCIP:$GWCPORT/$SERVLET/rest/seed/seedRequestFile.xml"}
+         */
+        if (seedRequestFile == null || !seedRequestFile.isFile()) {
+            throw new IllegalArgumentException("The seedRequestFile must not be null or empty");
+        }
+        String url = this.buildSeedRequestNameXMLURL(seedRequestName);
+
+        final String result = this.post(url, seedRequestFile, GeoServerRESTPublisher.Format.TXT_XML);
+        return result != null;
+    }
+
+    /**
+     * @param layerName the layer name seeding task to look for
+     * @return a list of pending (scheduled) and running tasks for all the
+     * layers.
+     * @throws org.codehaus.jackson.map.JsonMappingException
+     * @throws IllegalArgumentException if the layerName is null or empty.
+     */
+    public GlobalSeedStatus getLayerSeedingStatus(String layerName)
+            throws JsonMappingException {
+        GlobalSeedStatus globalSeedStatus = null;
+        if (Util.isEmpty(layerName)) {
+            throw new IllegalArgumentException("The layerName may not be null or empty");
+        }
+        String url = HTTPUtils.append("/rest/seed/", layerName, ".json").toString();
+        String seedingStatus = this.load(url);
+        if (!Util.isEmpty(seedingStatus)) {
+            try {
+                globalSeedStatus = this.mapper.readValue(seedingStatus, GlobalSeedStatus.class);
+            } catch (IOException ioe) {
+                LOGGER.error("Error parsing the seeding status: " + ioe);
+                throw new JsonMappingException("Error parsing the quota configuration: " + ioe);
+            }
+        }
+        return globalSeedStatus;
+    }
+
+    /**
+     * @return a list of pending (scheduled) and running tasks for all the
+     * layers.
+     * @throws org.codehaus.jackson.map.JsonMappingException
+     */
+    public GlobalSeedStatus getGlobalSeedingStatus() throws JsonMappingException {
+        GlobalSeedStatus globalSeedStatus = null;
+        String seedingStatus = this.load("/rest/seed.json");
+        if (!Util.isEmpty(seedingStatus)) {
+            try {
+                globalSeedStatus = this.mapper.readValue(seedingStatus, GlobalSeedStatus.class);
+            } catch (IOException ioe) {
+                LOGGER.error("Error parsing the seeding status: " + ioe);
+                throw new JsonMappingException("Error parsing the quota configuration: " + ioe);
+            }
+        }
+        return globalSeedStatus;
+    }
+
+    /**
+     * Add a new seed request assigning it a name.
+     *
+     * @param wmsLayerBody the SEED REQUEST file.
+     * @param seedRequestName the seed request name to use.<b>Note the the seed
+     * request name must match the name of the seed request in the xml
+     * representation.</b>
+     *
+     * @return <TT>true</TT> if the operation completed successfully.
+     * @throws IllegalArgumentException if the wmsLayerBody or the
+     * seedRequestName are null or empty.
+     */
+    public boolean addSeedRequest(final String wmsLayerBody, final String seedRequestName)
+            throws IllegalArgumentException {
+        /*
+         * This is the equivalent call with cUrl:
+         *
+         * {@code curl -v -u geowebcache:secured -XPUT -H "Content-type: text/xml" -d wmsLayerBody  
+         * "http://$GWCIP:$GWCPORT/$SERVLET/rest/seed/seedRequestFile.xml"}
+         */
+        if (Util.isEmpty(wmsLayerBody)) {
+            throw new IllegalArgumentException("The wmsLayerBody must not be null or empty");
+        }
+        String url = this.buildSeedRequestNameXMLURL(seedRequestName);
+
+        final String result = this.post(url, wmsLayerBody, GeoServerRESTPublisher.Format.TXT_XML);
+        return result != null;
+    }
+
+    /**
+     * Terminate a seed request task.
+     *
+     * @param seedRequestName the seed request name to use.<b>Note the the seed
+     * request name must match the name of the seed request in the xml
+     * representation.</b>
+     * @param truncateSeedType the type of truncation
+     *
+     * @return <TT>true</TT> if the operation completed successfully.
+     * @throws IllegalArgumentException if the seedRequestName is null or empty.
+     */
+    public boolean truncateSeedRequestTask(final String seedRequestName,
+            final GWCTruncateSeedType truncateSeedType)
+            throws IllegalArgumentException {
+        /*
+         * This is the equivalent call with cUrl:
+         *
+         * {@code curl -v -u geowebcache:secured -d "kill_all=all"  
+         * "http://$GWCIP:$GWCPORT/$SERVLET/rest/seed"}
+         */
+        if (Util.isEmpty(seedRequestName)) {
+            throw new IllegalArgumentException("The seedRequestName may not be null or empty");
+        }
+        String url = HTTPUtils.append("/rest/seed/", seedRequestName).toString();
+        NameValuePair[] parameters = new NameValuePair[1];
+        parameters[0] = new NameValuePair("kill_all", truncateSeedType.name());
+        final String result = this.post(url, parameters);
+        return result != null;
+    }
+
+    private String buildSeedRequestNameXMLURL(final String seedRequestName) {
+        if (Util.isEmpty(seedRequestName)) {
+            throw new IllegalArgumentException("The seedRequestName may not be null or empty");
+        }
+        return this.buildSeedRequestRESTXMLPath(seedRequestName);
+    }
+
+    private String buildSeedRequestRESTXMLPath(String seedRequestName) {
+        return HTTPUtils.append("/rest/seed/", seedRequestName, ".xml").toString();
+    }
+    // </editor-fold>
+
     // <editor-fold desc="/layers" defaultstate="collapsed">
+    //==========================================================================
+    //=== LAYERS
+    //==========================================================================
+    /**
+     * Get summary info about all Layers.
+     *
+     * @return summary info about Layers as a {@link RESTLayerList}
+     */
+    public RESTLayerList getLayers() {
+        String url = "/rest/layers.xml";
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("### Retrieving layers from " + url);
+        }
+//        LOGGER.info("--->> Layer response: " + load(url));
+        return RESTLayerList.build(this.load(url));
+    }
+
     /**
      * Get detailed info about a given Layer.
-     * 
-     * @param name the layer name
+     *
+     * @param layerName the layer name
      * @return a GWCRESTWMSLayer with layer information or null
      */
-    public GWCRESTWMSLayer getLayer(String name) {
-        if (name == null || name.isEmpty())
+    public GWCRESTWMSLayer getLayer(String layerName) {
+        if (Util.isEmpty(layerName)) {
             throw new IllegalArgumentException("Layername may not be null");
+        }
         String nameEncoded = null;
         try {
-            nameEncoded = URLEncoder.encode(name, "UTF-8");
+            nameEncoded = URLEncoder.encode(layerName, "UTF-8");
         } catch (UnsupportedEncodingException ex) {
             LOGGER.error("Error encoding layer name: " + ex);
         }
-        String url = HTTPUtils.append("/rest/layers/", nameEncoded, ".xml").toString();
+        String url = this.buildLayerRESTPath(nameEncoded);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("### Retrieving layer from " + url);
         }
-        GWCRESTWMSLayer layer = GWCRESTWMSLayer.build(load(url));
+        GWCRESTWMSLayer layer = GWCRESTWMSLayer.build(this.load(url));
         return layer;
     }
+
+    /**
+     * Add a new GWC's layer assigning it a name.
+     *
+     * @param wmsLayerFile the wmsLayer file.
+     * @param layerName the layer's name to use.<b>Note the the layer's name
+     * must match the name of the layer in the xml representation.</b>
+     *
+     * @return <TT>true</TT> if the operation completed successfully.
+     * @throws IllegalArgumentException if the wmsLayerFile or the layerName are
+     * null or empty.
+     */
+    public boolean addLayer(final File wmsLayerFile, final String layerName)
+            throws IllegalArgumentException {
+        /*
+         * This is the equivalent call with cUrl:
+         *
+         * {@code curl -v -u geowebcache:secured -XPUT -H "Content-type: text/xml" -d @wmsLayerFile.xml  
+         * "http://$GWCIP:$GWCPORT/$SERVLET/rest/layers/layerName.xml"}
+         */
+        if (wmsLayerFile == null || !wmsLayerFile.isFile()) {
+            throw new IllegalArgumentException("The wmsLayerFile may not be null or empty");
+        }
+        String url = this.buildLayerNameURL(layerName);
+
+        final String result = this.put(url, wmsLayerFile, GeoServerRESTPublisher.Format.TXT_XML);
+        return result != null;
+    }
+
+    /**
+     * Add a new GWC's layer assigning it a name.
+     *
+     * @param wmsLayerBody the full wmsLayer document as a String.
+     * @param layerName the layer's name to use.<b>Note the the layer's name
+     * must match the name of the layer in the xml representation.</b>
+     *
+     * @return <TT>true</TT> if the operation completed successfully.
+     * @throws IllegalArgumentException if the wmsLayerBody or the layerName are
+     * null or empty.
+     */
+    public boolean addLayer(final String wmsLayerBody, final String layerName)
+            throws IllegalArgumentException {
+        /*
+         * This is the equivalent call with cUrl:
+         *
+         * {@code curl -v -u geowebcache:secured -XPUT -H "Content-type: text/xml" -d @wmsLayerBody  
+         * "http://$GWCIP:$GWCPORT/$SERVLET/rest/layers/layerName.xml"}
+         */
+        if (Util.isEmpty(wmsLayerBody)) {
+            throw new IllegalArgumentException("The wmsLayerBody may not be null or empty");
+        }
+        String url = this.buildLayerNameURL(layerName);
+
+        final String result = this.put(url, wmsLayerBody, GeoServerRESTPublisher.Format.TXT_XML);
+        return result != null;
+    }
+
+    private String buildLayerNameURL(final String layerName) {
+        if (Util.isEmpty(layerName)) {
+            throw new IllegalArgumentException("The layerName may not be null or empty");
+        }
+        return this.buildLayerRESTPath(layerName);
+    }
+
+    /**
+     * Update a Layer.
+     *
+     * @param wmsLayerBody the full wmsLayer document as a String.
+     * @param layerName the layer's name to use.<b>Note the the layer's name
+     * must match the name of the layer in the xml representation.</b>
+     *
+     * @return <TT>true</TT> if the operation completed successfully.
+     * @throws IllegalArgumentException if the layer file or the layer name are
+     * null or empty.
+     */
+    public boolean updateLayer(final String wmsLayerBody, final String layerName)
+            throws IllegalArgumentException {
+        /*
+         * This is the equivalent call with cUrl:
+         *
+         * {@code curl -v -u geowebcache:secured -XPOST -H "Content-type: text/xml" -d @layerFile.xml  
+         * "http://$GWCIP:$GWCPORT/$SERVLET/rest/layers/layerName.xml"}
+         */
+        if (Util.isEmpty(wmsLayerBody)) {
+            throw new IllegalArgumentException("The wmsLayerBody may not be null or empty");
+        }
+        String url = this.buildLayerNameURL(layerName);
+
+        final String result = this.post(url, wmsLayerBody, GeoServerRESTPublisher.Format.TXT_XML);
+        return result != null;
+    }
+
+    /**
+     * Update a Layer.
+     *
+     * @param wmsLayerFile the File containing the wmsLayer document.
+     * @param layerName the layer's name to use.<b>Note the the layer's name
+     * must match the name of the layer in the xml representation.</b>
+     *
+     * @return <TT>true</TT> if the operation completed successfully.
+     * @throws IllegalArgumentException if the layer file or the layer name are
+     * null or empty.
+     */
+    public boolean updateLayer(final File wmsLayerFile, final String layerName)
+            throws IllegalArgumentException {
+        /*
+         * This is the equivalent call with cUrl:
+         *
+         * {@code curl -v -u geowebcache:secured -XPOST -H "Content-type: text/xml" -d @layerFile.xml  
+         * "http://$GWCIP:$GWCPORT/$SERVLET/rest/layers/layerName.xml"}
+         */
+        if (wmsLayerFile == null || !wmsLayerFile.isFile()) {
+            throw new IllegalArgumentException("Unable to update layer using a null parameter file");
+        }
+        String url = this.buildLayerNameURL(layerName);
+
+        final String result = this.post(url, wmsLayerFile, GeoServerRESTPublisher.Format.TXT_XML);
+        return result != null;
+    }
+
+    /**
+     * Check if a Layer exists in the configured GeoWebCache instance. User can
+     * choose if log a possible exception or not
+     *
+     * @param layerName the name of the layer to check for.
+     * @return <TT>true</TT> on HTTP 200, <TT>false</TT> on HTTP 404
+     * @throws RuntimeException if any other HTTP code than 200 or 404 was
+     * retrieved.
+     */
+    public boolean existsLayer(String layerName) {
+        String url = this.buildLayerRESTPath(layerName);
+//        String composed = Util.appendQuietOnNotFound(quietOnNotFound, url);
+        return exists(url);
+    }
+
+    /**
+     * remove a layer
+     *
+     * @param layerName
+     * @return true if success
+     */
+    public boolean removeLayer(final String layerName) {
+        if (layerName == null) {
+            if (LOGGER.isErrorEnabled()) {
+                LOGGER.error("Null layerName : " + layerName);
+            }
+            return false;
+        }
+        String url = this.buildLayerRESTPath(layerName);
+
+        boolean result = this.delete(url);
+        if (result) {
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info("Layer successfully removed: " + layerName);
+            }
+        } else {
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn("Error removing layer " + layerName);
+            }
+        }
+
+        return result;
+    }
+
+    private String buildLayerRESTPath(String layerName) {
+        return HTTPUtils.append("/rest/layers/", layerName, ".xml").toString();
+    }
     // </editor-fold>
-    
+
+    private String post(String url, NameValuePair[] parameters) {
+        LOGGER.info("Posting from REST path " + url);
+        return HTTPUtils.post(restURL + url, null, parameters, gwcUser, gwcPass);
+    }
+
+    private String post(String url, String content, Format format) {
+        LOGGER.info("Posting from REST path " + url);
+        return HTTPUtils.post(restURL + url, content, format.getContentType(), gwcUser, gwcPass);
+    }
+
+    private String post(String url, File contentFile, Format format) {
+        LOGGER.info("Posting from REST path " + url);
+        return HTTPUtils.post(restURL + url, contentFile, format.getContentType(), gwcUser, gwcPass);
+    }
+
+    private String put(String url, String content, Format format) {
+        LOGGER.info("Putting from REST path " + url);
+        return HTTPUtils.put(restURL + url, content, format.getContentType(), gwcUser, gwcPass);
+    }
+
+    private String put(String url, File contentFile, Format format) {
+        LOGGER.info("Putting from REST path " + url);
+        return HTTPUtils.put(restURL + url, contentFile, format.getContentType(), gwcUser, gwcPass);
+    }
+
     private String load(String url) {
         LOGGER.info("Loading from REST path " + url);
-        String response = HTTPUtils.get(restURL + url, gwcUser, gwcPass);
-        return response;
+        return HTTPUtils.get(restURL + url, gwcUser, gwcPass);
     }
-    
+
+    private boolean delete(String url) {
+        LOGGER.info("Deleting from REST path " + url);
+        return HTTPUtils.delete(restURL + url, gwcUser, gwcPass);
+    }
+
+    private boolean exists(String url) {
+        LOGGER.info("Checking existence from REST path " + url);
+        return HTTPUtils.exists(restURL + url, gwcUser, gwcPass);
+    }
+
 }

--- a/src/main/java/it/geosolutions/geoserver/rest/GeoWebCacheRESTManager.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/GeoWebCacheRESTManager.java
@@ -1,0 +1,127 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest;
+
+import it.geosolutions.geoserver.rest.decoder.gwc.GWCRESTWMSLayer;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.logging.Level;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Nazzareno Sileno - CNR IMAA geoSDI Group
+ * @email nazzareno.sileno@geosdi.org
+ */
+public class GeoWebCacheRESTManager {
+
+        private final static Logger LOGGER = LoggerFactory.getLogger(GeoWebCacheRESTManager.class);
+    
+    /**
+     * GeoWebCache instance base URL. E.g.: <TT>http://localhost:8080/geowebcache</TT>.
+     */
+    private final String restURL;
+
+    /**
+     * GeoWebCache instance privileged username, with read & write permission on REST API
+     */
+    private final String gwcUser;
+
+    /**
+     * GeoWebCache instance password for privileged username with r&w permission on REST API
+     */
+    private final String gwcPass;
+    
+    /**
+     * Creates a <TT>GeoWebCacheRESTManager</TT> to connect against a GeoWebCache instance with the given URL and user credentials.
+     * 
+     * @param restURL the base GeoWebCache URL (e.g.: <TT>http://localhost:8080/geowebcache</TT>)
+     * @param username auth credential
+     * @param password auth credential
+     */
+    public GeoWebCacheRESTManager(String restURL, String username, String password) {
+        this.restURL = HTTPUtils.decurtSlash(restURL);
+        this.gwcUser = username;
+        this.gwcPass = password;
+
+        URL url = null;
+        try {
+            url = new URL(restURL);
+        } catch (MalformedURLException ex) {
+            LOGGER.error("Bad URL: Calls to GeoWebCache are going to fail" , ex);
+        }
+    }
+    
+    /**
+     * Check if a GeoWebCache instance is running at the given URL.
+     * <BR>
+     * Return <TT>true</TT> if the configured GeoWebCache is up and replies to REST requests.
+     * <BR>
+     * Send a HTTP GET request to the configured URL.<BR>
+     * Return <TT>true</TT> if a HTTP 200 code (OK) is read from the HTTP response;
+     * any other response code, or connection error, will return a
+     * <TT>false</TT> boolean.
+     *
+     * @return true if a GeoWebCache instance was found at the configured URL.
+     */
+    public boolean existGeoWebCache() {
+        return HTTPUtils.httpPing(restURL + "/rest/", gwcUser, gwcPass);
+    }
+    
+    // <editor-fold desc="/layers" defaultstate="collapsed">
+    /**
+     * Get detailed info about a given Layer.
+     * 
+     * @param name the layer name
+     * @return a GWCRESTWMSLayer with layer information or null
+     */
+    public GWCRESTWMSLayer getLayer(String name) {
+        if (name == null || name.isEmpty())
+            throw new IllegalArgumentException("Layername may not be null");
+        String nameEncoded = null;
+        try {
+            nameEncoded = URLEncoder.encode(name, "UTF-8");
+        } catch (UnsupportedEncodingException ex) {
+            LOGGER.error("Error encoding layer name: " + ex);
+        }
+        String url = HTTPUtils.append("/rest/layers/", nameEncoded, ".xml").toString();
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("### Retrieving layer from " + url);
+        }
+        GWCRESTWMSLayer layer = GWCRESTWMSLayer.build(load(url));
+        return layer;
+    }
+    // </editor-fold>
+    
+    private String load(String url) {
+        LOGGER.info("Loading from REST path " + url);
+        String response = HTTPUtils.get(restURL + url, gwcUser, gwcPass);
+        return response;
+    }
+    
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/HTTPUtils.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/HTTPUtils.java
@@ -25,6 +25,7 @@
 
 package it.geosolutions.geoserver.rest;
 
+import it.geosolutions.geoserver.rest.GeoServerRESTPublisher.Format;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,6 +39,7 @@ import org.apache.commons.httpclient.Credentials;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.httpclient.NameValuePair;
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
 import org.apache.commons.httpclient.auth.AuthScope;
 import org.apache.commons.httpclient.methods.DeleteMethod;
@@ -172,7 +174,7 @@ public class HTTPUtils {
      * @return the HTTP response or <TT>null</TT> on errors.
      */
     public static String putXml(String url, String content, String username, String pw) {
-        return put(url, content, "text/xml", username, pw);
+        return put(url, content, Format.TXT_XML.getContentType(), username, pw);
     }
 
     /**
@@ -247,7 +249,7 @@ public class HTTPUtils {
      * @return the HTTP response or <TT>null</TT> on errors.
      */
     public static String postXml(String url, String content, String username, String pw) {
-        return post(url, content, "text/xml", username, pw);
+        return post(url, content, Format.TXT_XML.getContentType(), username, pw);
     }
 
     /**
@@ -265,6 +267,12 @@ public class HTTPUtils {
      */
     public static String post(String url, RequestEntity requestEntity, String username, String pw) {
         return send(new PostMethod(url), url, requestEntity, username, pw);
+    }
+
+    public static String post(String url, RequestEntity requestEntity, NameValuePair[] parameters, String username, String pw) {
+        PostMethod postMethod = new PostMethod(url);
+        postMethod.addParameters(parameters);
+        return send(postMethod, url, requestEntity, username, pw);
     }
 
     /**

--- a/src/main/java/it/geosolutions/geoserver/rest/Util.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/Util.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.jdom.Element;
 
 /**
  *
@@ -62,6 +63,60 @@ public static final String QUIET_ON_NOT_FOUND_PARAM = "quietOnNotFound=";
         return styles;
     }
     
+    public static List<String> getElementsChildrenStringContent(Element elementRoot){
+        return getElementsChildrenContent(elementRoot, "string");
+    }
+
+    public static List<String> getElementsChildrenContent(Element elementRoot, String childrensName){
+        assert(elementRoot != null) : "The passed elementRoot must be not null";
+        assert(childrensName != null) : "The passed childrensName must be not null";
+        List<String> stringContentList = new ArrayList<String>();
+        for (Element listItem : (List<Element>) Util.safeList(elementRoot.getChildren(childrensName))) {
+            stringContentList.add(listItem.getText());
+        }
+        return stringContentList;
+    }
+    
+    public static Integer getIntValueFromText(String text){
+        Integer result = null;
+        if(text != null){
+            result = Integer.parseInt(text);
+        }
+        return result;
+    }
+
+    public static Float getFloatValueFromText(String text){
+        Float result = null;
+        if(text != null){
+            result = Float.parseFloat(text);
+        }
+        return result;
+    }
+
+    public static Double getDoubleValueFromText(String text){
+        Double result = null;
+        if(text != null){
+            result = Double.parseDouble(text);
+        }
+        return result;
+    }
+
+    public static Long getLongValueFromText(String text){
+        Long result = null;
+        if(text != null){
+            result = Long.parseLong(text);
+        }
+        return result;
+    }
+
+    public static Boolean getBooleanValueFromText(String text){
+        Boolean result = null;
+        if(text != null){
+            result = Boolean.parseBoolean(text);
+        }
+        return result;
+    }
+    
     /**
      * Append the quietOnNotFound parameter to the input URL
      * @param quietOnNotFound parameter
@@ -84,6 +139,15 @@ public static final String QUIET_ON_NOT_FOUND_PARAM = "quietOnNotFound=";
 
     public static <TK, TV> Map<TK, TV> safeMap(Map<TK, TV> map) {
         return map == null ? Collections.EMPTY_MAP : map;
+    }
+    
+    /**
+     * 
+     * @param stringValue
+     * @return true iff the stringValue is NULL or it is empty
+     */
+    public static boolean isEmpty(String stringValue){
+        return stringValue == null || stringValue.isEmpty();
     }
 
     public static char getParameterSeparator(String url) {

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCBounds.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCBounds.java
@@ -1,0 +1,148 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest.decoder.gwc;
+
+import it.geosolutions.geoserver.rest.Util;
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import org.jdom.Element;
+
+/**
+ * Parse <TT>Bounds</TT>s returned as XML REST objects.
+ *
+ * <P>This is the XML Schema representation:
+ * <PRE>
+ * {@code
+    <xs:complexType name="Bounds">
+      <xs:sequence>
+        <xs:element name="coords" type="gwc:coords"/>
+      </xs:sequence>
+      
+      <xs:complexType name="coords">
+        <xs:sequence>
+          <xs:element maxOccurs="4" minOccurs="4" name="double" type="xs:double"/>
+        </xs:sequence>
+      </xs:complexType>
+    </xs:complexType>
+ * }</PRE>
+ * @author Nazzareno Sileno
+ */
+public class GWCBounds {
+    
+    private final Element boundsElem;
+
+    public static GWCBounds build(String response) {
+        if (response == null) {
+            return null;
+        }
+
+        Element pb = JDOMBuilder.buildElement(response);
+        if (pb != null) {
+            return new GWCBounds(pb);
+        } else {
+            return null;
+        }
+    }
+
+    public GWCBounds(Element boundsElem) {
+        this.boundsElem = boundsElem;
+    }
+
+    public List<Double> getCoords() {
+        List<Double> coords = null;
+        final Element coordsRoot = boundsElem.getChild("coords");
+        if(coordsRoot != null){
+            coords = new ArrayList<Double>(4);
+            for (Element listItem : (List<Element>) Util.safeList(coordsRoot.getChildren())) {
+                coords.add(Util.getDoubleValueFromText(listItem.getChildText("double")));
+            }
+        }
+        return coords;
+    }
+    
+    public double getMinX() {
+        return this.getCoords().get(0);
+    }
+
+    public double getMinY() {
+        return this.getCoords().get(1);    
+    }
+    
+    public double getMaxX() {
+        return this.getCoords().get(2);
+    }
+    
+    public double getMaxY() {
+        return this.getCoords().get(3);
+    }
+    
+    public double getWidth() {
+        return this.getCoords().get(2) - this.getCoords().get(0);
+    }
+
+    public double getHeight() {
+        return this.getCoords().get(3) - this.getCoords().get(1);
+    }
+    
+    /**
+     * Minimal sanity check
+     * 
+     * @return whether min x < max x, min y < max y
+     */
+    public boolean isSane() {
+        return (getMinX() < getMaxX() && getMinY() < getMaxY());
+    }
+
+    public boolean isNull() {
+        return (getMinX() > getMaxX() || getMinY() > getMaxY());
+    }
+    
+    /**
+     * Outputs a string suitable for logging and other human-readable tasks
+     * 
+     * @return a readable string
+     */
+    public String getReadableString() {
+        return "Min X: " + getMinX() + " Min Y: " + getMinY() + 
+                " Max X: " + getMaxX() + " Max Y: " + getMaxY();
+    }
+    
+    public String toKMLLatLonBox() {
+        return "<LatLonBox>" + toKMLBox() + "</LatLonBox>";
+    }
+
+    public String toKMLLatLonAltBox() {
+        return "<LatLonAltBox>" + toKMLBox() + "</LatLonAltBox>";
+    }
+    
+    private String toKMLBox() {
+        return "<north>" + Double.toString(getMaxY()) + "</north>" + "<south>"
+                + Double.toString(getMinY()) + "</south>" + "<east>" + Double.toString(getMaxX())
+                + "</east>" + "<west>" + Double.toString(getMinX()) + "</west>";
+    }
+    
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCCaseNormalize.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCCaseNormalize.java
@@ -1,0 +1,77 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest.decoder.gwc;
+
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import org.jdom.Element;
+
+/**
+ * Parse <TT>CaseNormalize</TT>s returned as XML REST objects.
+ *
+ * <P>This is the XML Schema representation:
+ * <PRE>
+ * {@code
+    <xs:complexType name="CaseNormalize">
+      <xs:sequence>
+        <xs:element name="case" type="xs:string">
+        </xs:element>
+        <xs:element maxOccurs="1" minOccurs="0" name="locale" type="xs:string">
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+ * }</PRE>
+ * @author Nazzareno Sileno
+ */
+public class GWCCaseNormalize {
+    
+    private final Element caseNormalizeElem;
+
+    public static GWCCaseNormalize build(String response) {
+        if (response == null) {
+            return null;
+        }
+
+        Element pb = JDOMBuilder.buildElement(response);
+        if (pb != null) {
+            return new GWCCaseNormalize(pb);
+        } else {
+            return null;
+        }
+    }
+
+    public GWCCaseNormalize(Element caseNormalizeElem) {
+        this.caseNormalizeElem = caseNormalizeElem;
+    }
+
+    public String getCase() {
+        return this.caseNormalizeElem.getChildText("case");
+    }
+
+    public String getLocale() {
+        return this.caseNormalizeElem.getChildText("locale");
+    }
+    
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCExpirationRule.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCExpirationRule.java
@@ -1,0 +1,78 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest.decoder.gwc;
+
+import it.geosolutions.geoserver.rest.Util;
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import org.jdom.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parse <TT>ExpirationRule</TT>s returned as XML REST objects.
+ *
+ * <P>This is the XML Schema representation:
+ * <PRE>
+ * {@code
+    <xs:complexType name="ExpirationRule">
+      <xs:attribute name="minZoom" type="xs:int"/>
+      <xs:attribute name="expiration" type="xs:int"/>
+    </xs:complexType>
+ * }</PRE>
+ * @author Nazzareno Sileno
+ */
+public class GWCExpirationRule {
+    
+    private final static Logger LOGGER = LoggerFactory.getLogger(GWCExpirationRule.class);
+    
+    private final Element expirationRuleElem;
+
+    public static GWCExpirationRule build(String response) {
+        if (response == null) {
+            return null;
+        }
+
+        Element pb = JDOMBuilder.buildElement(response);
+        if (pb != null) {
+            return new GWCExpirationRule(pb);
+        } else {
+            return null;
+        }
+    }
+
+    public GWCExpirationRule(Element expirationRuleElem) {
+        this.expirationRuleElem = expirationRuleElem;
+    }
+    
+    public Integer getMinZoom() {
+        return Util.getIntValueFromText(expirationRuleElem.getAttributeValue("minZoom"));
+    }
+    
+    public Integer getExpiration() {
+        return Util.getIntValueFromText(expirationRuleElem.getAttributeValue("expiration"));
+    }
+
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCFileRasterFilter.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCFileRasterFilter.java
@@ -1,0 +1,114 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest.decoder.gwc;
+
+import it.geosolutions.geoserver.rest.Util;
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import org.jdom.Element;
+
+/**
+ * Parse <TT>FileRasterFilter</TT>s returned as XML REST objects.
+ *
+ * <P>This is the XML Schema representation:
+ * <PRE>
+ * {@code
+    <xs:complexType name="FileRasterFilter">
+      <xs:sequence>
+        <xs:element minOccurs="1" name="name" type="xs:string">
+        </xs:element>
+        <xs:element minOccurs="0" name="zoomStart" type="xs:integer">
+        </xs:element>
+        <xs:element minOccurs="1" name="zoomStop" type="xs:integer">
+        </xs:element>
+        <xs:element minOccurs="0" name="resample" type="xs:boolean">
+        </xs:element>
+        <xs:element minOccurs="0" name="preload" type="xs:boolean">
+        </xs:element>
+        <xs:element minOccurs="0" name="debug" type="xs:boolean">
+        </xs:element>
+        <xs:element minOccurs="1" name="storagePath" type="xs:string">
+        </xs:element>
+        <xs:element minOccurs="1" name="fileExtension" type="xs:string">
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+ * }</PRE>
+ * @author Nazzareno Sileno
+ */
+public class GWCFileRasterFilter {
+    
+    private final Element fileRasterFilterElem;
+
+    public static GWCFileRasterFilter build(String response) {
+        if (response == null) {
+            return null;
+        }
+
+        Element pb = JDOMBuilder.buildElement(response);
+        if (pb != null) {
+            return new GWCFileRasterFilter(pb);
+        } else {
+            return null;
+        }
+    }
+
+    public GWCFileRasterFilter(Element fileRasterFilter) {
+        this.fileRasterFilterElem = fileRasterFilter;
+    }
+
+    public String getName() {
+        return this.fileRasterFilterElem.getChildText("name");
+    }
+    
+    public Integer getZoomStart() {
+        return Util.getIntValueFromText(fileRasterFilterElem.getChildText("zoomStart"));
+    }
+
+    public Integer getZoomStop() {
+        return Util.getIntValueFromText(fileRasterFilterElem.getChildText("zoomStop"));
+    }
+    
+    public Boolean getResample() {
+        return Util.getBooleanValueFromText(fileRasterFilterElem.getChildText("resample"));
+    }
+
+    public Boolean getPreload() {
+        return Util.getBooleanValueFromText(fileRasterFilterElem.getChildText("preload"));
+    }
+
+    public Boolean getDebug() {
+        return Util.getBooleanValueFromText(fileRasterFilterElem.getChildText("debug"));
+    }
+    //
+    public String getStoragePath() {
+        return this.fileRasterFilterElem.getChildText("storagePath");
+    }
+    
+    public String getFileExtension() {
+        return this.fileRasterFilterElem.getChildText("fileExtension");
+    }
+    
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCFloatParameterFilter.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCFloatParameterFilter.java
@@ -1,0 +1,100 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest.decoder.gwc;
+
+import it.geosolutions.geoserver.rest.Util;
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import org.jdom.Element;
+
+/**
+ * Parse <TT>FloatParameterFilter</TT>s returned as XML REST objects.
+ *
+ * <P>This is the XML Schema representation:
+ * <PRE>
+ * {@code
+    <xs:complexType name="FloatParameterFilter">
+      <xs:sequence>
+        <xs:element name="key" type="xs:string">
+        </xs:element>
+        <xs:element maxOccurs="1" minOccurs="0" name="defaultValue" type="xs:string">
+        </xs:element>
+        <xs:element name="values" type="gwc:FloatList">
+        </xs:element>
+        <xs:element name="threshold" type="xs:float">
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+ * }</PRE>
+ * @author Nazzareno Sileno
+ */
+public class GWCFloatParameterFilter {
+    
+    private final Element floatParameterFilterElem;
+
+    public static GWCFloatParameterFilter build(String response) {
+        if (response == null) {
+            return null;
+        }
+
+        Element pb = JDOMBuilder.buildElement(response);
+        if (pb != null) {
+            return new GWCFloatParameterFilter(pb);
+        } else {
+            return null;
+        }
+    }
+
+    public GWCFloatParameterFilter(Element floatParameterFilterElem) {
+        this.floatParameterFilterElem = floatParameterFilterElem;
+    }
+
+    public String getKey() {
+        return this.floatParameterFilterElem.getChildText("key");
+    }
+
+    public String getDefaultValue() {
+        return this.floatParameterFilterElem.getChildText("defaultValue");
+    }
+
+    public List<Float> getValues() {
+        List<Float> result = null;
+        final Element floatListRoot = floatParameterFilterElem.getChild("values");
+        if(floatListRoot != null){
+            result = new ArrayList<Float>();
+            for(Element listItem : (List<Element>) Util.safeList(floatListRoot.getChildren())){
+                result.add(Util.getFloatValueFromText(listItem.getChildText("float")));
+            }
+        }
+        return result;
+    }    
+    
+    public Float getThreshold() {
+        return Util.getFloatValueFromText(this.floatParameterFilterElem.getChildText("threshold"));
+    }
+    
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCFormatModifier.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCFormatModifier.java
@@ -1,0 +1,103 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest.decoder.gwc;
+
+import it.geosolutions.geoserver.rest.Util;
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import org.jdom.Element;
+
+/**
+ * Parse <TT>FormatModifier</TT>s returned as XML REST objects.
+ *
+ * <P>This is the XML Schema representation:
+ * <PRE>
+ * {@code
+    <xs:complexType name="FormatModifier">
+        <xs:sequence>
+          <xs:element minOccurs="1" name="responseFormat" type="xs:string">
+          </xs:element>
+          <xs:element minOccurs="0" name="requestFormat" type="xs:string">
+          </xs:element>
+          <xs:element minOccurs="0" name="transparent" type="xs:boolean">
+          </xs:element>
+          <xs:element minOccurs="0" name="bgColor" type="xs:string">
+          </xs:element>
+          <xs:element minOccurs="0" name="palette" type="xs:string">
+          </xs:element>
+          <xs:element minOccurs="0" name="compressionQuality" type="xs:float">
+          </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+ * }</PRE>
+ * @author Nazzareno Sileno
+ */
+public class GWCFormatModifier {
+    
+    private final Element formatModifierElem;
+
+    public static GWCFormatModifier build(String response) {
+        if (response == null) {
+            return null;
+        }
+
+        Element pb = JDOMBuilder.buildElement(response);
+        if (pb != null) {
+            return new GWCFormatModifier(pb);
+        } else {
+            return null;
+        }
+    }
+
+    public GWCFormatModifier(Element formatModifierElem) {
+        this.formatModifierElem = formatModifierElem;
+    }
+    
+    public String getResponseFormat() {
+        return formatModifierElem.getChildText("responseFormat");
+    }
+
+    public String getRequestFormat() {
+        return formatModifierElem.getChildText("requestFormat");
+    }
+
+    public Boolean getTransparent() {
+        return Util.getBooleanValueFromText(formatModifierElem.getChildText("transparent"));
+    }
+
+    public String getBGColor() {
+        return formatModifierElem.getChildText("bgColor");
+    }
+
+    public String getPalette() {
+        return formatModifierElem.getChildText("palette");
+    }
+
+    public Float getCompressionQuality() {
+        return Util.getFloatValueFromText(formatModifierElem.
+                getChildText("compressionQuality"));
+    }
+    
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCGeoRssFeed.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCGeoRssFeed.java
@@ -1,0 +1,108 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest.decoder.gwc;
+
+import it.geosolutions.geoserver.rest.Util;
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import org.jdom.Element;
+
+/**
+ * Parse <TT>GeoRssFeed</TT>s returned as XML REST objects.
+ *
+ * <P>This is the XML Schema representation:
+ * <PRE>
+ * {@code
+    <xs:complexType name="GeoRssFeed">
+      <xs:sequence>
+        <xs:element minOccurs="1" name="feedUrl" type="xs:string">
+        </xs:element>
+        <xs:element minOccurs="0" name="gridSetId" type="xs:string">
+        </xs:element>
+        <xs:element minOccurs="1" name="pollInterval" type="xs:integer">
+        </xs:element>
+        <xs:element minOccurs="0" name="operation" type="xs:string">
+        </xs:element>
+        <xs:element minOccurs="0" name="format" type="xs:string">
+        </xs:element>
+        <xs:element minOccurs="0" name="seedingThreads" type="xs:integer">
+        </xs:element>
+        <xs:element minOccurs="1" name="maxMaskLevel" type="xs:integer">
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+ * }</PRE>
+ * @author Nazzareno Sileno
+ */
+public class GWCGeoRssFeed {
+    
+    private final Element geoRssFeedElem;
+
+    public static GWCGeoRssFeed build(String response) {
+        if (response == null) {
+            return null;
+        }
+
+        Element pb = JDOMBuilder.buildElement(response);
+        if (pb != null) {
+            return new GWCGeoRssFeed(pb);
+        } else {
+            return null;
+        }
+    }
+
+    public GWCGeoRssFeed(Element geoRssFeedElem) {
+        this.geoRssFeedElem = geoRssFeedElem;
+    }
+    
+    public String getFeedUrl() {
+        return geoRssFeedElem.getChildText("feedUrl");
+    }
+
+    public String getGridSetId() {
+        return geoRssFeedElem.getChildText("gridSetId");
+    }
+    
+    public Integer getPollInterval() {
+        return Util.getIntValueFromText(geoRssFeedElem.getChildText("pollInterval"));
+    }
+
+    public String getOperation() {
+        return geoRssFeedElem.getChildText("operation");
+    }
+
+    public String getFormat() {
+        return geoRssFeedElem.getChildText("format");
+    }
+
+    public Integer getSeedingThreads() {
+        return Util.getIntValueFromText(geoRssFeedElem.getChildText("seedingThreads"));
+    }
+
+    public Integer getMaxMaskLevel() {
+        return Util.getIntValueFromText(geoRssFeedElem.getChildText("maxMaskLevel"));
+    }
+    
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCGridSubset.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCGridSubset.java
@@ -1,0 +1,107 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest.decoder.gwc;
+
+import it.geosolutions.geoserver.rest.Util;
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import org.jdom.Element;
+
+/**
+ * Parse <TT>FormatModifier</TT>s returned as XML REST objects.
+ *
+ * <P>This is the XML Schema representation:
+ * <PRE>
+ * {@code
+    <xs:complexType name="GridSubset">
+        <xs:sequence>
+          <xs:element name="gridSetName" type="xs:string">
+          </xs:element>
+          <xs:element minOccurs="0" name="extent" type="gwc:Bounds">
+          </xs:element>
+          <xs:element minOccurs="0" name="zoomStart" type="xs:integer">
+          </xs:element>
+          <xs:element minOccurs="0" name="zoomStop" type="xs:integer">
+          </xs:element>
+          <xs:element minOccurs="0" name="minCachedLevel" type="xs:integer">
+          </xs:element>
+          <xs:element minOccurs="0" name="maxCachedLevel" type="xs:integer">
+          </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+ * }</PRE>
+ * @author Nazzareno Sileno
+ */
+public class GWCGridSubset {
+    
+    private final Element gridSubsetElem;
+
+    public static GWCGridSubset build(String response) {
+        if (response == null) {
+            return null;
+        }
+
+        Element pb = JDOMBuilder.buildElement(response);
+        if (pb != null) {
+            return new GWCGridSubset(pb);
+        } else {
+            return null;
+        }
+    }
+
+    public GWCGridSubset(Element formatModifierElem) {
+        this.gridSubsetElem = formatModifierElem;
+    }
+    
+    public String getGridSetName() {
+        return gridSubsetElem.getChildText("gridSetName");
+    }
+
+    public GWCBounds getExtent() {
+        GWCBounds bounds = null;
+        final Element extent = gridSubsetElem.getChild("extent");
+        if(extent != null){
+            bounds = new GWCBounds(extent);
+        }
+        return bounds;
+    }
+
+    public Integer getZoomStart() {
+        return Util.getIntValueFromText(gridSubsetElem.getChildText("zoomStart"));
+    }
+
+    public Integer getZoomStop() {
+        return Util.getIntValueFromText(gridSubsetElem.getChildText("zoomStop"));
+    }
+
+    public Integer getMinCachedLevel() {
+        return Util.getIntValueFromText(gridSubsetElem.getChildText("minCachedLevel"));
+    }
+
+    public Integer getMaxCachedLevel() {
+        return Util.getIntValueFromText(gridSubsetElem.getChildText("maxCachedLevel"));
+    }
+
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCLayerMetaInformation.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCLayerMetaInformation.java
@@ -1,0 +1,90 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest.decoder.gwc;
+
+import it.geosolutions.geoserver.rest.Util;
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import java.util.List;
+import org.jdom.Element;
+
+/**
+ * Parse <TT>LayerMetaInformation</TT>s returned as XML REST objects.
+ *
+ * <P>This is the XML Schema representation:
+ * <PRE>
+ * {@code
+    <xs:complexType name="LayerMetaInformation">
+        <xs:sequence>
+          <xs:element minOccurs="1" name="title" type="xs:string">
+          </xs:element>
+          <xs:element minOccurs="0" name="description" type="xs:string">
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="keywords" type="gwc:KeywordsType">
+          </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+ * }</PRE>
+ * @author Nazzareno Sileno
+ */
+public class GWCLayerMetaInformation {
+    
+    private final Element layerMetaInformationElem;
+
+    public static GWCLayerMetaInformation build(String response) {
+        if (response == null) {
+            return null;
+        }
+
+        Element pb = JDOMBuilder.buildElement(response);
+        if (pb != null) {
+            return new GWCLayerMetaInformation(pb);
+        } else {
+            return null;
+        }
+    }
+
+    public GWCLayerMetaInformation(Element layerMetaInformationElem) {
+        this.layerMetaInformationElem = layerMetaInformationElem;
+    }
+    
+    public String getTitle() {
+        return layerMetaInformationElem.getChildText("title");
+    }
+
+    public String getDescription() {
+        return layerMetaInformationElem.getChildText("description");
+    }
+
+    public List<String> getKeywordsType() {
+        List<String> keywordsTypeList = null;
+        final Element keywordsRoot = this.layerMetaInformationElem.getChild("keywords");
+        if(keywordsRoot != null){
+            keywordsTypeList = Util.getElementsChildrenStringContent(keywordsRoot);
+        }
+        return keywordsTypeList;
+    }
+    
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCParameterFilters.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCParameterFilters.java
@@ -1,0 +1,110 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest.decoder.gwc;
+
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import org.jdom.Element;
+
+/**
+ * Parse <TT>ParameterFilters</TT>s returned as XML REST objects.
+ *
+ * <P>This is the XML Schema representation:
+ * <PRE>
+ * {@code
+    <xs:complexType name="ParameterFilters">
+      <xs:sequence maxOccurs="unbounded" minOccurs="0">
+        <xs:choice>
+          <xs:element name="regexParameterFilter" type="gwc:RegexParameterFilter">
+          </xs:element>
+          <xs:element name="floatParameterFilter" type="gwc:FloatParameterFilter">
+          </xs:element>
+          <xs:element name="stringParameterFilter" type="gwc:StringParameterFilter">
+          </xs:element>
+        </xs:choice>
+      </xs:sequence>
+    </xs:complexType>
+ * }</PRE>
+ * @author Nazzareno Sileno
+ */
+public class GWCParameterFilters {
+    
+    private final Element parameterFiltersElem;
+
+    public static GWCParameterFilters build(String response) {
+        if (response == null) {
+            return null;
+        }
+
+        Element pb = JDOMBuilder.buildElement(response);
+        if (pb != null) {
+            return new GWCParameterFilters(pb);
+        } else {
+            return null;
+        }
+    }
+
+    public GWCParameterFilters(Element parameterFiltersElem) {
+        this.parameterFiltersElem = parameterFiltersElem;
+    }
+
+    public GWCRegexParameterFilter getRegexParameterFilter(){
+        GWCRegexParameterFilter regexParameterFilter = null;
+        final Element regexParameterFilterRoot = parameterFiltersElem.getChild("regexParameterFilter");
+        if(regexParameterFilterRoot != null){
+            regexParameterFilter = new GWCRegexParameterFilter(regexParameterFilterRoot);
+        }
+        return regexParameterFilter;
+    }
+
+    public GWCFloatParameterFilter getFloatParameterFilter(){
+        GWCFloatParameterFilter floatParameterFilter = null;
+        final Element floatParameterFilterRoot = parameterFiltersElem.getChild("floatParameterFilter");
+        if(floatParameterFilterRoot != null){
+            floatParameterFilter = new GWCFloatParameterFilter(floatParameterFilterRoot);
+        }
+        return floatParameterFilter;
+    }
+
+    public GWCStringParameterFilter getStringParameterFilter(){
+        GWCStringParameterFilter stringParameterFilter = null;
+        final Element stringParameterFilterRoot = parameterFiltersElem.getChild("stringParameterFilter");
+        if(stringParameterFilterRoot != null){
+            stringParameterFilter = new GWCStringParameterFilter(stringParameterFilterRoot);
+        }
+        return stringParameterFilter;
+    }
+    
+    public boolean isRegexParameterFilter(){
+        return this.getRegexParameterFilter() != null;
+    }
+    public boolean isFloatParameterFilter(){
+        return this.getFloatParameterFilter() != null;
+    }
+    public boolean isStringParameterFilter(){
+        return this.getStringParameterFilter()!= null;
+    }
+    
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCRESTWMSLayer.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCRESTWMSLayer.java
@@ -1,0 +1,257 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2011 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest.decoder.gwc;
+
+import it.geosolutions.geoserver.rest.decoder.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import it.geosolutions.geoserver.rest.encoder.authorityurl.AuthorityURLInfo;
+import it.geosolutions.geoserver.rest.encoder.authorityurl.GSAuthorityURLInfoEncoder;
+import it.geosolutions.geoserver.rest.encoder.identifier.GSIdentifierInfoEncoder;
+import it.geosolutions.geoserver.rest.encoder.identifier.IdentifierInfo;
+import it.geosolutions.geoserver.rest.encoder.metadatalink.GSMetadataLinkInfoEncoder;
+import it.geosolutions.geoserver.rest.encoder.metadatalink.ResourceMetadataLinkInfo;
+
+import org.jdom.Element;
+import org.jdom.Namespace;
+
+/**
+ * Parse <TT>wmsLayer</TT>s returned as XML REST objects.
+ *
+ * <P>This is the XML REST representation:
+ * <PRE>
+ * {@code
+    <wmsLayer>
+      <metaInformation>
+      <name>img states</name>
+        <title>Nicer title for Image States</title>
+        <description>This is a description. Fascinating.</description>
+      </metaInformation>
+      <mimeFormats>
+        <string>image/gif</string>
+        <string>image/jpeg</string>
+        <string>image/png</string>
+        <string>image/png8</string>
+      </mimeFormats>
+      <gridSubsets>
+        <gridSubset>
+          <gridSetName>EPSG:4326</gridSetName>
+          <extent>
+            <coords>
+              <double>-129.6</double>
+              <double>3.45</double>
+              <double>-62.1</double>
+              <double>70.9</double>
+            </coords>
+          </extent>
+        </gridSubset>
+      </gridSubsets>
+      <expireCacheList>
+        <expirationRule minZoom="0" expiration="60" />
+      </expireCacheList>
+      <expireClientsList>
+        <expirationRule minZoom="0" expiration="500" />
+      </expireClientsList>
+      <wmsUrl>
+        <string>http://demo.opengeo.org/geoserver/wms</string>
+      </wmsUrl>
+      <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
+      <transparent>false</transparent>
+      <bgColor>0x0066FF</bgColor>
+    </wmsLayer>
+ * }</PRE>
+ * @author Nazzareno Sileno
+ */
+public class GWCRESTWMSLayer {
+	protected final Element wmsLayerElem;
+
+    public static GWCRESTWMSLayer build(String response) {
+        if(response == null)
+            return null;
+        
+        Element pb = JDOMBuilder.buildElement(response);
+        if(pb != null)
+            return new GWCRESTWMSLayer(pb);
+        else
+            return null;
+	}
+
+	public GWCRESTWMSLayer(Element layerElem) {
+		this.wmsLayerElem = layerElem;
+	}
+        
+        public String getName() {
+        	return wmsLayerElem.getChildText("name");
+	}
+
+        public String getTitle() {
+		Element metaInformation = wmsLayerElem.getChild("metaInformation");
+		return metaInformation.getChildText("title");
+	}
+        
+        public String getDescription() {
+		Element metaInformation = wmsLayerElem.getChild("metaInformation");
+		return metaInformation.getChildText("description");
+	}
+        
+        public List<String> getMimeFormats() {
+		List<String> mimeFormatsList = new ArrayList<String>();
+		final Element mimeFormatsRoot = wmsLayerElem.getChild("mimeFormats");
+		if (mimeFormatsRoot != null) {
+                    for (Element listItem : (List<Element>) mimeFormatsRoot.getChildren()) {
+			mimeFormatsList.add(listItem.getChildText("string"));
+                    }
+		}
+		return mimeFormatsList;
+	}
+        
+//	public boolean getEnabled(){
+//		return Boolean.parseBoolean(wmsLayerElem.getChildText("enabled"));
+//	}
+//	
+//	public boolean getQueryable(){
+//		return Boolean.parseBoolean(wmsLayerElem.getChildText("queryable"));
+//	}
+//	
+//	public boolean getAdvertised(){
+//		return Boolean.parseBoolean(wmsLayerElem.getChildText("advertised"));
+//	}
+//
+//	public String getTypeString() {
+//		return wmsLayerElem.getChildText("type");
+//	}
+//
+//	public Type getType() {
+//		return Type.get(getTypeString());
+//	}
+//
+//	public String getDefaultStyle() {
+//		Element defaultStyle = wmsLayerElem.getChild("defaultStyle");
+//		return defaultStyle == null? null : defaultStyle.getChildText("name");
+//  	}
+//	
+//	public RESTStyleList getStyles() {
+//		RESTStyleList styleList = null;
+//		final Element stylesRoot = wmsLayerElem.getChild("styles");
+//		if (stylesRoot != null) {
+//			styleList = new RESTStyleList(stylesRoot);
+//		}
+//		return styleList;
+//	}
+//
+//	public String getDefaultStyleWorkspace() {
+//		Element defaultStyle = wmsLayerElem.getChild("defaultStyle");
+//		return defaultStyle == null? null : defaultStyle.getChildText("workspace");
+//  	}
+//
+//	public String getTitle() {
+//		Element resource = wmsLayerElem.getChild("resource");
+//		return resource.getChildText("title");
+//	}
+//
+//	public String getAbstract() {
+//		Element resource = wmsLayerElem.getChild("resource");
+//		return resource.getChildText("abstract");
+//	}
+//
+//	public String getNameSpace() {
+//		Element resource = wmsLayerElem.getChild("resource");
+//		return resource.getChild("namespace").getChildText("name");
+//	}
+//
+//    /**
+//     * Get the URL to retrieve the featuretype.
+//     * <PRE>{@code
+//        <resource class="featureType">
+//        <name>tasmania_cities</name>
+//        <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/workspaces/topp/datastores/taz_shapes/featuretypes/tasmania_cities.xml" type="application/xml"/>
+//    </resource>
+//     * }</CODE>
+//     */
+//    public String getResourceUrl() {
+//	Element resource = wmsLayerElem.getChild("resource");
+//        Element atom = resource.getChild("link", Namespace.getNamespace("atom", "http://www.w3.org/2005/Atom"));
+//        return atom.getAttributeValue("href");
+//    }
+//    
+//    
+//	/**
+//	 * Decodes the list of AuthorityURLInfo from the GeoServer Layer
+//	 * 
+//	 * @return the list of GSAuthorityURLInfoEncoder
+//	 */
+//	public List<GSAuthorityURLInfoEncoder> getEncodedAuthorityURLInfoList() {
+//		List<GSAuthorityURLInfoEncoder> authorityURLList = null;
+//
+//		final Element authorityURLsRoot = wmsLayerElem.getChild("authorityURLs");
+//		if (authorityURLsRoot != null) {
+//			final List<Element> authorityURLs = authorityURLsRoot.getChildren();
+//			if (authorityURLs != null) {
+//				authorityURLList = new ArrayList<GSAuthorityURLInfoEncoder>(
+//						authorityURLs.size());
+//				for (Element authorityURL : authorityURLs) {
+//					final GSAuthorityURLInfoEncoder authEnc = new GSAuthorityURLInfoEncoder();
+//					authEnc.setName(authorityURL
+//							.getChildText(AuthorityURLInfo.name.name()));
+//					authEnc.setHref(authorityURL
+//							.getChildText(AuthorityURLInfo.href.name()));
+//					authorityURLList.add(authEnc);
+//				}
+//			}
+//		}
+//		return authorityURLList;
+//	}
+//
+//	/**
+//	 * Decodes the list of IdentifierInfo from the GeoServer Layer
+//	 * 
+//	 * @return the list of IdentifierInfoEncoder
+//	 */
+//	public List<GSIdentifierInfoEncoder> getEncodedIdentifierInfoList() {
+//		List<GSIdentifierInfoEncoder> idList = null;
+//
+//		final Element idRoot = wmsLayerElem.getChild("identifiers");
+//		if (idRoot != null) {
+//			final List<Element> identifiers = idRoot.getChildren();
+//			if (identifiers != null) {
+//				idList = new ArrayList<GSIdentifierInfoEncoder>(
+//						identifiers.size());
+//				for (Element identifier : identifiers) {
+//					final GSIdentifierInfoEncoder idEnc = new GSIdentifierInfoEncoder();
+//					idEnc.setAuthority(identifier
+//							.getChildText(IdentifierInfo.authority.name()));
+//					idEnc.setIdentifier(identifier
+//							.getChildText(IdentifierInfo.identifier.name()));
+//					idList.add(idEnc);
+//				}
+//			}
+//		}
+//		return idList;
+//	}
+    
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCRESTWMSLayer.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCRESTWMSLayer.java
@@ -25,20 +25,15 @@
 
 package it.geosolutions.geoserver.rest.decoder.gwc;
 
-import it.geosolutions.geoserver.rest.decoder.*;
+import it.geosolutions.geoserver.rest.Util;
 import java.util.ArrayList;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
-import it.geosolutions.geoserver.rest.encoder.authorityurl.AuthorityURLInfo;
-import it.geosolutions.geoserver.rest.encoder.authorityurl.GSAuthorityURLInfoEncoder;
-import it.geosolutions.geoserver.rest.encoder.identifier.GSIdentifierInfoEncoder;
-import it.geosolutions.geoserver.rest.encoder.identifier.IdentifierInfo;
-import it.geosolutions.geoserver.rest.encoder.metadatalink.GSMetadataLinkInfoEncoder;
-import it.geosolutions.geoserver.rest.encoder.metadatalink.ResourceMetadataLinkInfo;
 
 import org.jdom.Element;
-import org.jdom.Namespace;
 
 /**
  * Parse <TT>wmsLayer</TT>s returned as XML REST objects.
@@ -84,174 +79,386 @@ import org.jdom.Namespace;
       <transparent>false</transparent>
       <bgColor>0x0066FF</bgColor>
     </wmsLayer>
+    This is the XML Schema representation:
+    <xs:complexType name="WmsLayer">
+     <xs:complexContent>
+         <xs:sequence>
+                   <xs:element minOccurs="0" name="blobStoreId" type="xs:string">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="enabled" type="xs:boolean">
+                   </xs:element>
+                   <xs:element name="name" type="xs:string">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="metaInformation" type="gwc:LayerMetaInformation">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="mimeFormats" type="gwc:MimeFormats">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="infoMimeFormats" type="gwc:MimeFormats">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="formatModifiers" type="gwc:formatModifiers">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="grids" type="gwc:DEPRECATEDgrids">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="gridSubsets" type="gwc:GridSubsets">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="updateSources" type="gwc:UpdateSources">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="requestFilters" type="gwc:RequestFilters">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="useETags" type="xs:boolean">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="metaWidthHeight" type="gwc:MetaWidthHeight">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="expireCache" type="xs:integer">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="expireCacheList" type="gwc:ExpireList">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="expireClients" type="xs:integer">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="expireClientsList" type="gwc:ExpireList">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="backendTimeout" type="xs:integer">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="cacheBypassAllowed" type="xs:boolean">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="queryable" type="xs:boolean">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="wmsQueryLayers" type="xs:string">
+                   </xs:element>
+                   <xs:element minOccurs="0" name="parameterFilters" type="gwc:ParameterFilters">
+                   </xs:element>
+           <xs:element minOccurs="0" name="wmsUrl" type="gwc:WmsUrl">
+           </xs:element>
+           <xs:element minOccurs="0" name="wmsLayers" type="xs:string">
+           </xs:element>
+           <xs:element minOccurs="0" name="wmsStyles" type="xs:string">
+           </xs:element>
+           <xs:element minOccurs="0" name="gutter" type="xs:integer">
+           </xs:element>
+           <xs:element minOccurs="0" name="errorMime" type="xs:string">
+           </xs:element>
+           <xs:element minOccurs="0" name="wmsVersion">
+             <xs:simpleType>
+               <xs:restriction base="xs:string">
+                 <xs:enumeration value="1.0.0"/>
+                 <xs:enumeration value="1.1.0"/>
+                 <xs:enumeration value="1.1.1"/>
+               </xs:restriction>
+             </xs:simpleType>
+           </xs:element>
+           <xs:element minOccurs="0" name="httpUsername" type="xs:string">
+           </xs:element>
+           <xs:element minOccurs="0" name="httpPassword" type="xs:string">
+           </xs:element>
+           <xs:element minOccurs="0" name="proxyUrl" type="xs:string"/>
+           <xs:element minOccurs="0" name="tiled" type="xs:boolean">
+           </xs:element>
+           <xs:element minOccurs="0" name="transparent" type="xs:boolean">
+           </xs:element>
+           <xs:element minOccurs="0" name="bgColor" type="xs:string">
+           </xs:element>
+           <xs:element minOccurs="0" name="palette" type="xs:string">
+           </xs:element>
+           <xs:element minOccurs="0" name="vendorParameters" type="xs:string">
+           </xs:element>
+           <xs:element minOccurs="0" name="cachePrefix" type="xs:string">
+           </xs:element>
+           <xs:element minOccurs="0" name="concurrency" type="xs:positiveInteger">
+           </xs:element>
+         </xs:sequence>
+     </xs:complexContent>
+   </xs:complexType>
  * }</PRE>
  * @author Nazzareno Sileno
  */
 public class GWCRESTWMSLayer {
-	protected final Element wmsLayerElem;
+    
+    private final static Logger LOGGER = LoggerFactory.getLogger(GWCRESTWMSLayer.class);
+    
+    private final Element wmsLayerElem;
+    
+    public enum WMSVersion {
+
+        V1_0_0("1.0.0"),
+        V1_1_0("1.1.0"),
+        V1_1_1("1.1.1"),
+        UNKNOWN(null);
+
+        private final String restVersion;
+
+        private WMSVersion(String restVersion) {
+            this.restVersion = restVersion;
+        }
+
+        public static WMSVersion get(String restName) {
+            for (WMSVersion value : values()) {
+                if (value == UNKNOWN) {
+                    continue;
+                }
+                if (value.restVersion.equals(restName)) {
+                    return value;
+                }
+            }
+            return UNKNOWN;
+        }
+    };
 
     public static GWCRESTWMSLayer build(String response) {
-        if(response == null)
+        if (response == null) {
             return null;
-        
+        }
+
         Element pb = JDOMBuilder.buildElement(response);
-        if(pb != null)
+        if (pb != null) {
             return new GWCRESTWMSLayer(pb);
-        else
+        } else {
             return null;
-	}
+        }
+    }
 
-	public GWCRESTWMSLayer(Element layerElem) {
-		this.wmsLayerElem = layerElem;
-	}
-        
-        public String getName() {
-        	return wmsLayerElem.getChildText("name");
-	}
+    public GWCRESTWMSLayer(Element wmsLayerElem) {
+        this.wmsLayerElem = wmsLayerElem;
+    }
 
-        public String getTitle() {
-		Element metaInformation = wmsLayerElem.getChild("metaInformation");
-		return metaInformation.getChildText("title");
-	}
-        
-        public String getDescription() {
-		Element metaInformation = wmsLayerElem.getChild("metaInformation");
-		return metaInformation.getChildText("description");
-	}
-        
-        public List<String> getMimeFormats() {
-		List<String> mimeFormatsList = new ArrayList<String>();
-		final Element mimeFormatsRoot = wmsLayerElem.getChild("mimeFormats");
-		if (mimeFormatsRoot != null) {
-                    for (Element listItem : (List<Element>) mimeFormatsRoot.getChildren()) {
-			mimeFormatsList.add(listItem.getChildText("string"));
-                    }
-		}
-		return mimeFormatsList;
-	}
-        
-//	public boolean getEnabled(){
-//		return Boolean.parseBoolean(wmsLayerElem.getChildText("enabled"));
-//	}
-//	
-//	public boolean getQueryable(){
-//		return Boolean.parseBoolean(wmsLayerElem.getChildText("queryable"));
-//	}
-//	
-//	public boolean getAdvertised(){
-//		return Boolean.parseBoolean(wmsLayerElem.getChildText("advertised"));
-//	}
-//
-//	public String getTypeString() {
-//		return wmsLayerElem.getChildText("type");
-//	}
-//
-//	public Type getType() {
-//		return Type.get(getTypeString());
-//	}
-//
-//	public String getDefaultStyle() {
-//		Element defaultStyle = wmsLayerElem.getChild("defaultStyle");
-//		return defaultStyle == null? null : defaultStyle.getChildText("name");
-//  	}
-//	
-//	public RESTStyleList getStyles() {
-//		RESTStyleList styleList = null;
-//		final Element stylesRoot = wmsLayerElem.getChild("styles");
-//		if (stylesRoot != null) {
-//			styleList = new RESTStyleList(stylesRoot);
-//		}
-//		return styleList;
-//	}
-//
-//	public String getDefaultStyleWorkspace() {
-//		Element defaultStyle = wmsLayerElem.getChild("defaultStyle");
-//		return defaultStyle == null? null : defaultStyle.getChildText("workspace");
-//  	}
-//
-//	public String getTitle() {
-//		Element resource = wmsLayerElem.getChild("resource");
-//		return resource.getChildText("title");
-//	}
-//
-//	public String getAbstract() {
-//		Element resource = wmsLayerElem.getChild("resource");
-//		return resource.getChildText("abstract");
-//	}
-//
-//	public String getNameSpace() {
-//		Element resource = wmsLayerElem.getChild("resource");
-//		return resource.getChild("namespace").getChildText("name");
-//	}
-//
-//    /**
-//     * Get the URL to retrieve the featuretype.
-//     * <PRE>{@code
-//        <resource class="featureType">
-//        <name>tasmania_cities</name>
-//        <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="http://localhost:8080/geoserver/rest/workspaces/topp/datastores/taz_shapes/featuretypes/tasmania_cities.xml" type="application/xml"/>
-//    </resource>
-//     * }</CODE>
-//     */
-//    public String getResourceUrl() {
-//	Element resource = wmsLayerElem.getChild("resource");
-//        Element atom = resource.getChild("link", Namespace.getNamespace("atom", "http://www.w3.org/2005/Atom"));
-//        return atom.getAttributeValue("href");
-//    }
-//    
-//    
-//	/**
-//	 * Decodes the list of AuthorityURLInfo from the GeoServer Layer
-//	 * 
-//	 * @return the list of GSAuthorityURLInfoEncoder
-//	 */
-//	public List<GSAuthorityURLInfoEncoder> getEncodedAuthorityURLInfoList() {
-//		List<GSAuthorityURLInfoEncoder> authorityURLList = null;
-//
-//		final Element authorityURLsRoot = wmsLayerElem.getChild("authorityURLs");
-//		if (authorityURLsRoot != null) {
-//			final List<Element> authorityURLs = authorityURLsRoot.getChildren();
-//			if (authorityURLs != null) {
-//				authorityURLList = new ArrayList<GSAuthorityURLInfoEncoder>(
-//						authorityURLs.size());
-//				for (Element authorityURL : authorityURLs) {
-//					final GSAuthorityURLInfoEncoder authEnc = new GSAuthorityURLInfoEncoder();
-//					authEnc.setName(authorityURL
-//							.getChildText(AuthorityURLInfo.name.name()));
-//					authEnc.setHref(authorityURL
-//							.getChildText(AuthorityURLInfo.href.name()));
-//					authorityURLList.add(authEnc);
-//				}
-//			}
-//		}
-//		return authorityURLList;
-//	}
-//
-//	/**
-//	 * Decodes the list of IdentifierInfo from the GeoServer Layer
-//	 * 
-//	 * @return the list of IdentifierInfoEncoder
-//	 */
-//	public List<GSIdentifierInfoEncoder> getEncodedIdentifierInfoList() {
-//		List<GSIdentifierInfoEncoder> idList = null;
-//
-//		final Element idRoot = wmsLayerElem.getChild("identifiers");
-//		if (idRoot != null) {
-//			final List<Element> identifiers = idRoot.getChildren();
-//			if (identifiers != null) {
-//				idList = new ArrayList<GSIdentifierInfoEncoder>(
-//						identifiers.size());
-//				for (Element identifier : identifiers) {
-//					final GSIdentifierInfoEncoder idEnc = new GSIdentifierInfoEncoder();
-//					idEnc.setAuthority(identifier
-//							.getChildText(IdentifierInfo.authority.name()));
-//					idEnc.setIdentifier(identifier
-//							.getChildText(IdentifierInfo.identifier.name()));
-//					idList.add(idEnc);
-//				}
-//			}
-//		}
-//		return idList;
-//	}
+    public String getBlobStoreId() {
+        return wmsLayerElem.getChildText("blobStoreId");
+    }
+
+    public Boolean getEnabled() {
+        return Util.getBooleanValueFromText(wmsLayerElem.getChildText("enabled"));
+    }
+
+    public String getName() {
+        return wmsLayerElem.getChildText("name");
+    }
+
+    public GWCLayerMetaInformation getMetaInformation() {
+        GWCLayerMetaInformation layerMetaInformation = null;
+        final Element keywordsRoot = wmsLayerElem.getChild("keywords");
+        if(keywordsRoot != null){
+            layerMetaInformation = new GWCLayerMetaInformation(keywordsRoot);
+        }
+        return layerMetaInformation;
+    }
+
+    public List<String> getMimeFormats() {
+        List<String> mimeFormatsList = null;
+        final Element mimeFormatsRoot = wmsLayerElem.getChild("mimeFormats");
+        if(mimeFormatsRoot != null){
+            mimeFormatsList = Util.getElementsChildrenStringContent(mimeFormatsRoot);
+        }
+        return mimeFormatsList;
+    }
+
+    public List<String> getInfoMimeFormats() {
+        List<String> infoMimeFormatsList = null;
+        final Element infoMimeFormatsRoot = wmsLayerElem.getChild("infoMimeFormats");
+        if(infoMimeFormatsRoot != null){
+            infoMimeFormatsList = Util.getElementsChildrenStringContent(infoMimeFormatsRoot);
+        }
+        return infoMimeFormatsList;
+    }
+
+    public List<GWCFormatModifier> getFormatModifiers() {
+        List<GWCFormatModifier> formatModifierList = null;
+        final Element formatModifiersRoot = wmsLayerElem.getChild("formatModifiers");
+        if(formatModifiersRoot != null){
+            formatModifierList = new ArrayList<GWCFormatModifier>();
+            for (Element listItem : (List<Element>) Util.safeList(formatModifiersRoot.getChildren())) {
+                formatModifierList.add(new GWCFormatModifier(listItem));
+            }
+        }
+        return formatModifierList;
+    }
+
+    public List<GWCGridSubset> getGridSubsets() {
+        List<GWCGridSubset> gridSubsetList = null;
+        final Element gridSubsetsRoot = wmsLayerElem.getChild("gridSubsets");
+        if(gridSubsetsRoot != null){
+            gridSubsetList = new ArrayList<GWCGridSubset>();
+            for (Element listItem : (List<Element>) Util.safeList(gridSubsetsRoot.getChildren())) {
+                gridSubsetList.add(new GWCGridSubset(listItem));
+            }
+        }
+        return gridSubsetList;
+    }
+
+    public List<GWCGeoRssFeed> getUpdateSources() {
+        List<GWCGeoRssFeed> updateSourceList = null;
+        final Element updateSourcesRoot = wmsLayerElem.getChild("updateSources");
+        if(updateSourcesRoot != null){
+            updateSourceList = new ArrayList<GWCGeoRssFeed>();
+            for (Element listItem : (List<Element>) Util.safeList(updateSourcesRoot.getChildren())) {
+                updateSourceList.add(new GWCGeoRssFeed(listItem));
+            }
+        }
+        return updateSourceList;
+    }
+
+    public GWCRequestFilters getRequestFilters() {
+        GWCRequestFilters requestFilters = null;
+        final Element requestFiltersRoot = wmsLayerElem.getChild("requestFilters");
+        if(requestFiltersRoot != null){
+            requestFilters = new GWCRequestFilters(requestFiltersRoot);
+        }
+        return requestFilters;
+    }
     
+    
+    public Boolean getUseETags() {
+        return Util.getBooleanValueFromText(wmsLayerElem.getChildText("useETags"));
+    }
+
+    public List<Integer> getMetaWidthHeight() {
+        List<Integer> result = null;
+        final Element metaWidthHeightRoot = wmsLayerElem.getChild("metaWidthHeight");
+        if(metaWidthHeightRoot != null){
+            result = new ArrayList<Integer>(2);
+            for(Element listItem : (List<Element>) Util.safeList(metaWidthHeightRoot.getChildren())){
+                result.add(Util.getIntValueFromText(listItem.getChildText("int")));
+            }
+        }
+        return result;
+    }
+    
+    public Integer getExpireCache() {
+        return Util.getIntValueFromText(wmsLayerElem.getChildText("expireCache"));
+    }
+
+    public List<GWCExpirationRule> getExpireCacheList() {
+        List<GWCExpirationRule> expireCacheList = null;
+        final Element expireCacheListRoot = wmsLayerElem.getChild("expireCacheList");
+        if(expireCacheListRoot != null){
+            expireCacheList = new ArrayList<GWCExpirationRule>();
+            for (Element listItem : (List<Element>) Util.safeList(expireCacheListRoot.getChildren())) {
+                expireCacheList.add(new GWCExpirationRule(listItem));
+            }
+        }
+        return expireCacheList;
+    }
+    
+    public Integer getExpireClients() {
+        return Util.getIntValueFromText(wmsLayerElem.getChildText("expireClients"));
+    }
+    
+    public List<GWCExpirationRule> getExpireClientsList() {
+        List<GWCExpirationRule> expireCacheList = null;
+        final Element expireCacheListRoot = wmsLayerElem.getChild("expireClientsList");
+        if(expireCacheListRoot != null){
+            expireCacheList = new ArrayList<GWCExpirationRule>();
+            for (Element listItem : (List<Element>) Util.safeList(expireCacheListRoot.getChildren())) {
+                expireCacheList.add(new GWCExpirationRule(listItem));
+            }
+        }
+        return expireCacheList;
+    }
+    
+    public Integer getBackendTimeout() {
+        return Util.getIntValueFromText(wmsLayerElem.getChildText("backendTimeout"));
+    }
+    
+    public Boolean getCacheBypassAllowed() {
+        return Util.getBooleanValueFromText(wmsLayerElem.getChildText("cacheBypassAllowed"));
+    }
+
+    public Boolean getQueryable() {
+        return Util.getBooleanValueFromText(wmsLayerElem.getChildText("queryable"));
+    }
+
+    public String getWMSQueryLayers() {
+        return wmsLayerElem.getChildText("wmsQueryLayers");
+    }
+
+    public GWCParameterFilters getParameterFilters() {
+        GWCParameterFilters parameterFilters = null;
+        final Element parameterFiltersRoot = wmsLayerElem.getChild("parameterFilters");
+        if(parameterFiltersRoot != null){
+            parameterFilters = new GWCParameterFilters(parameterFiltersRoot);
+        }
+        return parameterFilters;
+    }
+
+    public List<String> getWmsUrl() {
+        List<String> wmsUrlList = null;
+        final Element wmsUrlRoot = wmsLayerElem.getChild("wmsUrl");
+        if(wmsUrlRoot != null){
+            wmsUrlList = Util.getElementsChildrenStringContent(wmsUrlRoot);
+        }
+        return wmsUrlList;
+    }
+
+    public String getWMSLayers() {
+        return wmsLayerElem.getChildText("wmsLayers");
+    }
+
+    public String getWMSStyles() {
+        return wmsLayerElem.getChildText("wmsStyles");
+    }
+    
+    public Integer getGutter() {
+        return Util.getIntValueFromText(wmsLayerElem.getChildText("gutter"));
+    }
+
+    public String getErrorMime() {
+        return wmsLayerElem.getChildText("errorMime");
+    }
+    
+    public WMSVersion getWMSVersion(){
+        return WMSVersion.get(wmsLayerElem.getChildText("wmsVersion"));
+    }
+    
+    public String getHTTPUsername() {
+        return wmsLayerElem.getChildText("httpUsername");
+    }
+
+    public String getHTTPPassword() {
+        return wmsLayerElem.getChildText("httpPassword");
+    }
+
+    public String getProxyUrl() {
+        return wmsLayerElem.getChildText("proxyUrl");
+    }
+
+    public Boolean getTiled() {
+        return Util.getBooleanValueFromText(wmsLayerElem.getChildText("tiled"));
+    }
+    
+    public Boolean getTransparent() {
+        return Util.getBooleanValueFromText(wmsLayerElem.getChildText("transparent"));
+    }
+    
+    public String getBGColor() {
+        return wmsLayerElem.getChildText("bgColor");
+    }
+
+    public String getPalette() {
+        return wmsLayerElem.getChildText("palette");
+    }
+
+    public String getVendorParameters() {
+        return wmsLayerElem.getChildText("vendorParameters");
+    }
+
+    public String getCachePrefix() {
+        return wmsLayerElem.getChildText("cachePrefix");
+    }
+
+    public String getConcurrency() {
+        return wmsLayerElem.getChildText("concurrency");
+    }
+    
+    public String getTitle() {
+        Element metaInformation = wmsLayerElem.getChild("metaInformation");
+        return metaInformation.getChildText("title");
+    }
+
+    public String getDescription() {
+        Element metaInformation = wmsLayerElem.getChild("metaInformation");
+        return metaInformation.getChildText("description");
+    }
+
+//    @Deprecated
+//    public DEPRECATEDgrids getGrids() {
+//        Element deprecatedGrids = wmsLayerElem.getChild("grids");
+//    }
 }

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCRegexParameterFilter.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCRegexParameterFilter.java
@@ -1,0 +1,94 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest.decoder.gwc;
+
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import org.jdom.Element;
+
+/**
+ * Parse <TT>RegexParameterFilter</TT>s returned as XML REST objects.
+ *
+ * <P>This is the XML Schema representation:
+ * <PRE>
+ * {@code
+    <xs:complexType name="RegexParameterFilter">
+      <xs:sequence>
+        <xs:element name="key" type="xs:string">
+        </xs:element>
+        <xs:element maxOccurs="1" minOccurs="0" name="defaultValue" type="xs:string">
+        </xs:element>
+        <xs:element maxOccurs="1" minOccurs="0" name="normalize" type="gwc:CaseNormalize">
+        </xs:element>
+        <xs:element name="regex" type="xs:string">
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+ * }</PRE>
+ * @author Nazzareno Sileno
+ */
+public class GWCRegexParameterFilter {
+    
+    private final Element regexParameterFilterElem;
+
+    public static GWCRegexParameterFilter build(String response) {
+        if (response == null) {
+            return null;
+        }
+
+        Element pb = JDOMBuilder.buildElement(response);
+        if (pb != null) {
+            return new GWCRegexParameterFilter(pb);
+        } else {
+            return null;
+        }
+    }
+
+    public GWCRegexParameterFilter(Element regexParameterFilterElem) {
+        this.regexParameterFilterElem = regexParameterFilterElem;
+    }
+
+    public String getKey() {
+        return this.regexParameterFilterElem.getChildText("key");
+    }
+
+    public String getDefaultValue() {
+        return this.regexParameterFilterElem.getChildText("defaultValue");
+    }
+
+    public GWCCaseNormalize getNormalize() {
+        GWCCaseNormalize normalize = null;
+        final Element normalizeRoot = regexParameterFilterElem.getChild("normalize");
+        if(normalizeRoot != null){
+            normalize = new GWCCaseNormalize(normalizeRoot);
+        }
+        return normalize;
+    }    
+    
+    public String getRegex() {
+        return this.regexParameterFilterElem.getChildText("regex");
+    }
+    
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCRequestFilters.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCRequestFilters.java
@@ -1,0 +1,103 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest.decoder.gwc;
+
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import org.jdom.Element;
+
+/**
+ * Parse <TT>RequestFilters</TT>s returned as XML REST objects.
+ *
+ * <P>This is the XML Schema representation:
+ * <PRE>
+ * {@code
+    <xs:complexType name="RequestFilters">
+      <xs:choice maxOccurs="unbounded" minOccurs="0">
+        <xs:element name="circularExtentFilter" type="gwc:circularExtentFilter">
+        </xs:element>
+        <xs:element name="wmsRasterFilter" type="gwc:WmsRasterFilter">
+        </xs:element>
+        <xs:element name="fileRasterFilter" type="gwc:FileRasterFilter">
+        </xs:element>
+      </xs:choice>
+    </xs:complexType>
+ * }</PRE>
+ * @author Nazzareno Sileno
+ */
+public class GWCRequestFilters {
+    
+    private final Element requestFiltersElem;
+
+    public static GWCRequestFilters build(String response) {
+        if (response == null) {
+            return null;
+        }
+
+        Element pb = JDOMBuilder.buildElement(response);
+        if (pb != null) {
+            return new GWCRequestFilters(pb);
+        } else {
+            return null;
+        }
+    }
+
+    public GWCRequestFilters(Element requestFiltersElem) {
+        this.requestFiltersElem = requestFiltersElem;
+    }
+
+    public String getCircularExtentFilter() {
+        return this.requestFiltersElem.getChildText("circularExtentFilter");
+    }
+    
+    public GWCWmsRasterFilter getWMSRasterFilter(){
+        GWCWmsRasterFilter wmsRasterFilter = null;
+        final Element wmsRasterFilterRoot = requestFiltersElem.getChild("wmsRasterFilter");
+        if(wmsRasterFilterRoot != null){
+            wmsRasterFilter = new GWCWmsRasterFilter(wmsRasterFilterRoot);
+        }
+        return wmsRasterFilter;
+    }
+
+    public GWCFileRasterFilter getFileRasterFilter(){
+        GWCFileRasterFilter fileRasterFilter = null;
+        final Element fileRasterFilterRoot = requestFiltersElem.getChild("fileRasterFilter");
+        if(fileRasterFilterRoot != null){
+            fileRasterFilter = new GWCFileRasterFilter(fileRasterFilterRoot);
+        }
+        return fileRasterFilter;
+    }
+    
+    public boolean isFileRasterFilter(){
+        return this.getFileRasterFilter() != null;
+    }
+    public boolean isWMSRasterFilter(){
+        return this.getWMSRasterFilter() != null;
+    }
+    public boolean isCircularExtentFilter(){
+        return this.getCircularExtentFilter()!= null;
+    }
+    
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCStringParameterFilter.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCStringParameterFilter.java
@@ -1,0 +1,101 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest.decoder.gwc;
+
+import it.geosolutions.geoserver.rest.Util;
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import java.util.List;
+import org.jdom.Element;
+
+/**
+ * Parse <TT>FloatParameterFilter</TT>s returned as XML REST objects.
+ *
+ * <P>This is the XML Schema representation:
+ * <PRE>
+ * {@code
+    <xs:complexType name="FloatParameterFilter">
+      <xs:sequence>
+        <xs:element name="key" type="xs:string">
+        </xs:element>
+        <xs:element maxOccurs="1" minOccurs="0" name="defaultValue" type="xs:string">
+        </xs:element>
+        <xs:element name="values" type="gwc:FloatList">
+        </xs:element>
+        <xs:element name="threshold" type="xs:float">
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+ * }</PRE>
+ * @author Nazzareno Sileno
+ */
+public class GWCStringParameterFilter {
+    
+    private final Element stringParameterFilterElem;
+
+    public static GWCStringParameterFilter build(String response) {
+        if (response == null) {
+            return null;
+        }
+
+        Element pb = JDOMBuilder.buildElement(response);
+        if (pb != null) {
+            return new GWCStringParameterFilter(pb);
+        } else {
+            return null;
+        }
+    }
+
+    public GWCStringParameterFilter(Element stringParameterFilterElem) {
+        this.stringParameterFilterElem = stringParameterFilterElem;
+    }
+
+    public String getKey() {
+        return this.stringParameterFilterElem.getChildText("key");
+    }
+
+    public String getDefaultValue() {
+        return this.stringParameterFilterElem.getChildText("defaultValue");
+    }
+    
+    public GWCCaseNormalize getNormalize() {
+        GWCCaseNormalize normalize = null;
+        final Element normalizeRoot = stringParameterFilterElem.getChild("normalize");
+        if(normalizeRoot != null){
+            normalize = new GWCCaseNormalize(normalizeRoot);
+        }
+        return normalize;
+    } 
+
+    public List<String> getValues() {
+        List<String> result = null;
+        final Element valuesRoot = stringParameterFilterElem.getChild("values");
+        if(valuesRoot != null){
+            result = Util.getElementsChildrenStringContent(valuesRoot);
+        }
+        return result;
+    }    
+    
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCWmsRasterFilter.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/GWCWmsRasterFilter.java
@@ -1,0 +1,120 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest.decoder.gwc;
+
+import it.geosolutions.geoserver.rest.Util;
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import org.jdom.Element;
+
+/**
+ * Parse <TT>WmsRasterFilter</TT>s returned as XML REST objects.
+ *
+ * <P>This is the XML Schema representation:
+ * <PRE>
+ * {@code
+    <xs:complexType name="WmsRasterFilter">
+      <xs:sequence>
+        <xs:element minOccurs="1" name="name" type="xs:string">
+        </xs:element>
+        <xs:element minOccurs="0" name="zoomStart" type="xs:integer">
+        </xs:element>
+        <xs:element minOccurs="1" name="zoomStop" type="xs:integer">
+        </xs:element>
+        <xs:element minOccurs="0" name="resample" type="xs:boolean">
+        </xs:element>
+        <xs:element minOccurs="0" name="preload" type="xs:boolean">
+        </xs:element>
+        <xs:element minOccurs="0" name="debug" type="xs:boolean">
+        </xs:element>
+        <xs:element minOccurs="0" name="wmsLayers" type="xs:string">
+        </xs:element>
+        <xs:element minOccurs="0" name="wmsStyles" type="xs:string">
+        </xs:element>
+        <xs:element minOccurs="0" name="backendTimeout" type="xs:string">
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+ * }</PRE>
+ * @author Nazzareno Sileno
+ */
+public class GWCWmsRasterFilter {
+    
+    private final Element wmsRasterFilterElem;
+
+    public static GWCWmsRasterFilter build(String response) {
+        if (response == null) {
+            return null;
+        }
+
+        Element pb = JDOMBuilder.buildElement(response);
+        if (pb != null) {
+            return new GWCWmsRasterFilter(pb);
+        } else {
+            return null;
+        }
+    }
+
+    public GWCWmsRasterFilter(Element wmsRasterFilterElem) {
+        this.wmsRasterFilterElem = wmsRasterFilterElem;
+    }
+
+    public String getName() {
+        return this.wmsRasterFilterElem.getChildText("name");
+    }
+    
+    public Integer getZoomStart() {
+        return Util.getIntValueFromText(wmsRasterFilterElem.getChildText("zoomStart"));
+    }
+
+    public Integer getZoomStop() {
+        return Util.getIntValueFromText(wmsRasterFilterElem.getChildText("zoomStop"));
+    }
+    
+    public Boolean getResample() {
+        return Util.getBooleanValueFromText(wmsRasterFilterElem.getChildText("resample"));
+    }
+
+    public Boolean getPreload() {
+        return Util.getBooleanValueFromText(wmsRasterFilterElem.getChildText("preload"));
+    }
+
+    public Boolean getDebug() {
+        return Util.getBooleanValueFromText(wmsRasterFilterElem.getChildText("debug"));
+    }
+    
+    public String getWmsLayers() {
+        return this.wmsRasterFilterElem.getChildText("wmsLayers");
+    }
+    
+    public String getWmsStyles() {
+        return this.wmsRasterFilterElem.getChildText("wmsStyles");
+    }
+    
+    public String getBackendTimeout() {
+        return this.wmsRasterFilterElem.getChildText("backendTimeout");
+    }
+    
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/diskquota/GWCExpirationPolicy.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/diskquota/GWCExpirationPolicy.java
@@ -1,0 +1,33 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package it.geosolutions.geoserver.rest.decoder.gwc.diskquota;
+
+/**
+ * Disk Quota policies: Least Frequently Used (LFU) and Least Recently Used (LRU)
+ * @author Nazzareno Sileno - CNR IMAA geoSDI Group
+ */
+public enum GWCExpirationPolicy {
+    LRU, LFU;
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/diskquota/GWCLayerQuota.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/diskquota/GWCLayerQuota.java
@@ -1,0 +1,97 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package it.geosolutions.geoserver.rest.decoder.gwc.diskquota;
+
+import java.io.Serializable;
+
+/**
+ * 
+ * @author groldan
+ * 
+ */
+public final class GWCLayerQuota implements Serializable {
+
+    private static final long serialVersionUID = 5726170502452942487L;
+
+    private String layer;
+
+    private GWCExpirationPolicy expirationPolicyName;
+
+    private GWCQuota quota;
+
+    /**
+     * @deprecated usage quota no longer tracked here but on the quota store. This field is
+     *             temporarily left here to avoid XStram parsing problems for older versions
+     */
+    @Deprecated
+    private transient GWCQuota usedQuota;
+
+    GWCLayerQuota() {
+        //
+    }
+
+    public GWCLayerQuota(final String layer, final GWCExpirationPolicy expirationPolicyName) {
+        this(layer, expirationPolicyName, null);
+    }
+
+    public GWCLayerQuota(final String layer, final GWCExpirationPolicy expirationPolicyName, GWCQuota quota) {
+        this.layer = layer;
+        this.expirationPolicyName = expirationPolicyName;
+        this.quota = quota;
+        readResolve();
+    }
+
+    /**
+     * Supports initialization of instance variables during XStream deserialization
+     * 
+     * @return
+     */
+    private Object readResolve() {
+        return this;
+    }
+
+    public GWCExpirationPolicy getExpirationPolicyName() {
+        return expirationPolicyName;
+    }
+
+    public String getLayer() {
+        return layer;
+    }
+
+    /**
+     * @return The layer's configured disk quota, or {@code null} if it has no max quota set
+     */
+    public GWCQuota getQuota() {
+        return quota;
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(getClass().getSimpleName()).append("[layer: ").append(layer)
+                .append(", Expiration policy: '").append(expirationPolicyName).append("', quota:")
+                .append(quota).append("]").toString();
+    }
+
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/diskquota/GWCQuota.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/diskquota/GWCQuota.java
@@ -1,0 +1,263 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package it.geosolutions.geoserver.rest.decoder.gwc.diskquota;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.text.NumberFormat;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonSetter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A <b>Mutable</b> representation of the disk usage of a given cache tile set, given by a value and
+ * a {@link StorageUnit storage unit}.
+ * <p>
+ * Instances of this class are <b>not</b> thread safe.
+ * </p>
+ * 
+ * @author groldan
+ * 
+ */
+public class GWCQuota implements Cloneable, Comparable<GWCQuota>, Serializable {
+
+    private static final long serialVersionUID = -3817255124248938529L;
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(GWCQuota.class);
+
+    private static final NumberFormat NICE_FORMATTER = NumberFormat.getNumberInstance();
+    static {
+        NICE_FORMATTER.setMinimumFractionDigits(1);
+        NICE_FORMATTER.setMaximumFractionDigits(2);
+    }
+
+    private Integer id;
+
+    private String tileSetId;
+
+    private BigInteger bytes;
+    
+    private GWCStorageUnit units;
+
+    public GWCQuota() {
+        this(BigInteger.ZERO);
+    }
+
+    public GWCQuota(BigInteger bytes) {
+        this.bytes = bytes;
+        this.units = GWCStorageUnit.B;
+    }
+
+    public GWCQuota(GWCQuota quota) {
+        id = quota.id;
+        tileSetId = quota.tileSetId;
+        bytes = quota.getBytes();
+        this.units = GWCStorageUnit.B;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getTileSetId() {
+        return tileSetId;
+    }
+
+    public void setTileSetId(String tileSetId) {
+        this.tileSetId = tileSetId;
+    }
+
+    public BigInteger getBytes() {
+        return bytes;
+    }
+
+    public void setBytes(BigInteger bytes) {
+        this.bytes = bytes;
+    }
+
+    @JsonSetter("value")
+    public void setBytes(long bytes) {
+        setBytes(BigInteger.valueOf(bytes));
+    }
+
+    @JsonCreator
+    public GWCQuota(@JsonProperty("value") double value, @JsonProperty("units")GWCStorageUnit units) {
+        this(BigDecimal.valueOf(value), units);
+    }
+
+    public GWCQuota(BigDecimal value, GWCStorageUnit units) {
+        this.bytes = units.toBytes(value);
+        //Setting unit as byte after the transformation
+        this.units = GWCStorageUnit.B;
+    }
+
+    /**
+     * Supports initialization of instance variables during XStream deserialization
+     * 
+     * @return
+     */
+    private Object readResolve() {
+        if (this.bytes == null) {
+            this.bytes = BigInteger.ZERO;
+        }
+
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        GWCStorageUnit bestFit = GWCStorageUnit.bestFit(bytes);
+        BigDecimal value = GWCStorageUnit.B.convertTo(new BigDecimal(bytes), bestFit);
+        return new StringBuilder(NICE_FORMATTER.format(value)).append(bestFit.toString())
+                .toString();
+    }
+
+    /**
+     * Adds {@code bytes} bytes to this quota
+     * 
+     * @param bytes
+     */
+    public void add(BigInteger bytes) {
+        this.bytes = this.bytes.add(bytes);
+    }
+
+    /**
+     * Shorthand for {@link #add(BigInteger) add(BigInteger.valueOf(bytes))}
+     */
+    public void addBytes(long bytes) {
+        this.bytes = this.bytes.add(BigInteger.valueOf(bytes));
+    }
+
+    /**
+     * Shorthand for {@link #add(BigInteger) add(units.toBytes(amount))}
+     */
+    public void add(double amount, GWCStorageUnit units) {
+        this.bytes = this.bytes.add(units.toBytes(amount));
+    }
+
+    /**
+     * Shorthand for {@link #add(BigInteger) add(quota.getBytes())}
+     */
+    public void add(final GWCQuota quota) {
+        this.bytes = this.bytes.add(quota.getBytes());
+    }
+
+    /**
+     * Subtracts {@code bytes} bytes from this quota
+     * 
+     * @param bytes
+     */
+    public void subtract(final BigInteger bytes) {
+        this.bytes = this.bytes.subtract(bytes);
+    }
+
+    /**
+     * Shorthand for {@link #subtract(BigInteger) subtract(quota.getBytes())}
+     */
+    public void subtract(final GWCQuota quota) {
+        subtract(quota.getBytes());
+    }
+
+    /**
+     * Shorthand for {@link #subtract(BigInteger) subtract(units.toBytes(amount))}
+     */
+    public void subtract(final double amount, final GWCStorageUnit units) {
+        subtract(units.toBytes(amount));
+    }
+
+    /**
+     * Returns the difference between this quota and the argument one, in this quota's units
+     * 
+     * @param quota
+     * @return
+     */
+    public GWCQuota difference(GWCQuota quota) {
+        BigInteger difference = this.bytes.subtract(quota.getBytes());
+        return new GWCQuota(difference);
+    }
+
+    /**
+     * Returns a more user friendly string representation of this quota, like in 1.1GB, 0.75MB, etc.
+     * 
+     * @return
+     */
+    public String toNiceString() {
+        GWCStorageUnit bestFit = GWCStorageUnit.bestFit(bytes);
+        BigDecimal value = GWCStorageUnit.B.convertTo(new BigDecimal(bytes), bestFit);
+        return new StringBuilder(NICE_FORMATTER.format(value)).append(' ')
+                .append(bestFit.toNiceString()).toString();
+    }
+
+    /**
+     * @param quota
+     *            quota to be compared against this one
+     * @return {@code this} or {@code quota}, the one that represents a lower amount
+     */
+    public GWCQuota min(GWCQuota quota) {
+        BigInteger min = this.bytes.min(quota.getBytes());
+        return this.bytes.equals(min) ? this : quota;
+    }
+
+    /**
+     * @see java.lang.Comparable#compareTo(java.lang.Object)
+     */
+    public int compareTo(GWCQuota o) {
+        if (o == null) {
+            throw new NullPointerException("Can't compare against null");
+        }
+        return bytes.compareTo(o.getBytes());
+    }
+
+    /**
+     * Shorthand for {@code setBytes(unit.convertTo(value, StorageUnit.B).toBigInteger())}
+     * 
+     * @param value
+     * @param unit
+     */
+    public void setValue(double value, GWCStorageUnit unit) {
+        setBytes(unit.convertTo(value, GWCStorageUnit.B).toBigInteger());
+    }
+
+    @Override
+    public GWCQuota clone() {
+        return new GWCQuota(this);
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    @JsonProperty("units")
+    public GWCStorageUnit getUnits() {
+        return this.units;
+    }
+
+    public void setUnits(GWCStorageUnit units) {
+        this.units = units;
+    }
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/diskquota/GWCQuotaConfigJSONWrapper.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/diskquota/GWCQuotaConfigJSONWrapper.java
@@ -1,0 +1,46 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package it.geosolutions.geoserver.rest.decoder.gwc.diskquota;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+/**
+ * @author Nazzareno Sileno - CNR IMAA geoSDI Group
+ * @email nazzareno.sileno@geosdi.org
+ */
+public class GWCQuotaConfigJSONWrapper {
+
+    @JsonProperty("gwcQuotaConfiguration")
+    private GWCQuotaConfiguration quotaConfiguration;
+
+    public GWCQuotaConfiguration getQuotaConfiguration() {
+        return quotaConfiguration;
+    }
+
+    public void setQuotaConfiguration(GWCQuotaConfiguration quotaConfiguration) {
+        this.quotaConfiguration = quotaConfiguration;
+    }
+
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/diskquota/GWCQuotaConfiguration.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/diskquota/GWCQuotaConfiguration.java
@@ -1,0 +1,305 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package it.geosolutions.geoserver.rest.decoder.gwc.diskquota;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Holds the quota configuration for all the registered layers as well as the instance wide settings
+ * such as cache disk block size, maximum number of concurrent cache clean ups, etc.
+ * 
+ * @author groldan
+ * 
+ */
+public class GWCQuotaConfiguration implements Cloneable, Serializable {
+
+    private static final long serialVersionUID = 4376471696761297546L;
+
+    @Deprecated
+    static final int DEFAULT_DISK_BLOCK_SIZE = 4096;
+
+    static final int DEFAULT_CLEANUP_FREQUENCY = 10;
+
+    static final TimeUnit DEFAULT_CLEANUP_UNITS = TimeUnit.SECONDS;
+
+    static final int DEFAULT_MAX_CONCURRENT_CLEANUPS = 2;
+
+    static GWCExpirationPolicy DEFAULT_GLOBAL_POLICY_NAME = GWCExpirationPolicy.LFU;
+    
+    private Boolean enabled;
+
+    @Deprecated
+    private transient Integer diskBlockSize;
+
+    private Integer cacheCleanUpFrequency;
+
+    private TimeUnit cacheCleanUpUnits;
+
+    private Integer maxConcurrentCleanUps;
+
+    private GWCExpirationPolicy globalExpirationPolicyName;
+
+    private GWCQuota globalQuota;
+
+    private transient Date lastCleanUpTime;
+
+    private List<GWCLayerQuota> layerQuotas;
+    
+    private String quotaStore;
+    
+    public void setDefaults() {
+        if (enabled == null) {
+            enabled = Boolean.FALSE;
+        }
+        if (diskBlockSize == null) {
+            diskBlockSize = DEFAULT_DISK_BLOCK_SIZE;
+        }
+        if (cacheCleanUpFrequency == null) {
+            cacheCleanUpFrequency = DEFAULT_CLEANUP_FREQUENCY;
+        }
+
+        if (maxConcurrentCleanUps == null) {
+            maxConcurrentCleanUps = DEFAULT_MAX_CONCURRENT_CLEANUPS;
+        }
+        if (cacheCleanUpUnits == null) {
+            cacheCleanUpUnits = DEFAULT_CLEANUP_UNITS;
+        }
+        if (globalExpirationPolicyName == null) {
+            globalExpirationPolicyName = DEFAULT_GLOBAL_POLICY_NAME;
+        }
+        if (globalQuota == null) {
+            globalQuota = new GWCQuota(500, GWCStorageUnit.MiB);
+        }
+    }
+
+    void setFrom(GWCQuotaConfiguration other) {
+        this.cacheCleanUpFrequency = other.cacheCleanUpFrequency;
+        this.cacheCleanUpUnits = other.cacheCleanUpUnits;
+        this.diskBlockSize = other.diskBlockSize;
+        this.enabled = other.enabled;
+        this.globalExpirationPolicyName = other.globalExpirationPolicyName;
+        this.globalQuota = other.globalQuota;
+        this.layerQuotas = other.layerQuotas == null ? null : new ArrayList<GWCLayerQuota>(
+                other.layerQuotas);
+        this.maxConcurrentCleanUps = other.maxConcurrentCleanUps;
+        this.quotaStore = other.quotaStore;
+    }
+
+    public Boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Deprecated
+    public Integer getDiskBlockSize() {
+        return diskBlockSize;
+    }
+
+    @Deprecated
+    public void setDiskBlockSize(int blockSizeBytes) {
+        if (blockSizeBytes <= 0) {
+            throw new IllegalArgumentException("Block size shall be a positive integer");
+        }
+        this.diskBlockSize = blockSizeBytes;
+    }
+
+    public Integer getCacheCleanUpFrequency() {
+        return cacheCleanUpFrequency;
+    }
+
+    public void setCacheCleanUpFrequency(int cacheCleanUpFrequency) {
+        if (cacheCleanUpFrequency < 0) {
+            throw new IllegalArgumentException("cacheCleanUpFrequency shall be a positive integer");
+        }
+        this.cacheCleanUpFrequency = cacheCleanUpFrequency;
+    }
+
+    public TimeUnit getCacheCleanUpUnits() {
+        return cacheCleanUpUnits;
+    }
+
+    public void setCacheCleanUpUnits(TimeUnit cacheCleanUpUnit) {
+        if (cacheCleanUpUnit == null) {
+            throw new IllegalArgumentException("cacheCleanUpUnits can't be null");
+        }
+        this.cacheCleanUpUnits = cacheCleanUpUnit;
+    }
+
+    /**
+     * @return the configured layer quotas, or {@code null} if not set
+     */
+    public List<GWCLayerQuota> getLayerQuotas() {
+        return layerQuotas == null ? null : new ArrayList<GWCLayerQuota>(layerQuotas);
+    }
+
+    public void setLayerQuotas(List<GWCLayerQuota> layerQuotas) {
+        this.layerQuotas = layerQuotas == null ? null : new ArrayList<GWCLayerQuota>(layerQuotas);
+    }
+
+    public void addLayerQuota(GWCLayerQuota quota) {
+        assert quota != null;
+        assert quota.getQuota() != null;
+        if (layerQuotas == null) {
+            layerQuotas = new ArrayList<GWCLayerQuota>();
+        }
+        this.layerQuotas.add(quota);
+    }
+
+    /**
+     * @return The layer quota for the given layer or {@code null} if no quota is being tracked for
+     *         that layer
+     */
+    public GWCLayerQuota layerQuota(final String layerName) {
+        if (layerQuotas != null) {
+            for (GWCLayerQuota lq : layerQuotas) {
+                if (lq.getLayer().equals(layerName)) {
+                    return lq;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public void remove(final GWCLayerQuota lq) {
+        if (layerQuotas != null) {
+            for (Iterator<GWCLayerQuota> it = layerQuotas.iterator(); it.hasNext();) {
+                if (it.next().getLayer().equals(lq.getLayer())) {
+                    it.remove();
+                }
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(getClass().getSimpleName());
+        sb.append("[");
+        if (null != getLayerQuotas()) {
+            for (GWCLayerQuota lq : getLayerQuotas()) {
+                sb.append("\n\t").append(lq);
+            }
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    public Integer getMaxConcurrentCleanUps() {
+        return maxConcurrentCleanUps;
+    }
+
+    public void setMaxConcurrentCleanUps(int nThreads) {
+        if (nThreads <= 0) {
+            throw new IllegalArgumentException(
+                    "maxConcurrentCleanUps shall be a positive integer: " + nThreads);
+        }
+        this.maxConcurrentCleanUps = nThreads;
+    }
+
+    /**
+     * @return the global quota, or {@code null} if not set
+     */
+    public GWCQuota getGlobalQuota() {
+        return this.globalQuota;
+    }
+
+    /**
+     * @param newQuota
+     *            the new global quota, or {@code null} to unset
+     */
+    public void setGlobalQuota(final GWCQuota newQuota) {
+        if (newQuota == null) {
+            this.globalQuota = null;
+        } else {
+            this.globalQuota = new GWCQuota(newQuota);
+        }
+    }
+
+    public GWCExpirationPolicy getGlobalExpirationPolicyName() {
+        return this.globalExpirationPolicyName;
+    }
+
+    public void setGlobalExpirationPolicyName(GWCExpirationPolicy policy) {
+        this.globalExpirationPolicyName = policy;
+    }
+
+    public void setLastCleanUpTime(Date date) {
+        this.lastCleanUpTime = date;
+    }
+
+    public Date getLastCleanUpTime() {
+        return this.lastCleanUpTime;
+    }
+
+    public Set<String> layerNames() {
+        Set<String> names = new HashSet<String>();
+        if (null != getLayerQuotas()) {
+            for (GWCLayerQuota lq : getLayerQuotas()) {
+                names.add(lq.getLayer());
+            }
+        }
+        return names;
+    }
+
+    @Override
+    public GWCQuotaConfiguration clone() {
+        GWCQuotaConfiguration clone;
+        try {
+            clone = (GWCQuotaConfiguration) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeException(e);
+        }
+        clone.lastCleanUpTime = lastCleanUpTime;
+        clone.globalQuota = globalQuota == null ? null : new GWCQuota(globalQuota);
+        clone.layerQuotas = layerQuotas == null ? null : new ArrayList<GWCLayerQuota>(layerQuotas);
+        return clone;
+    }
+
+    /**
+     * Returns the quota store name
+     * @return
+     */
+    public String getQuotaStore() {
+        return quotaStore;
+    }
+
+    /**
+     * Sets the quota store name
+     * @param quotaStore
+     */
+    public void setQuotaStore(String quotaStore) {
+        this.quotaStore = quotaStore;
+    }
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/diskquota/GWCStorageUnit.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/diskquota/GWCStorageUnit.java
@@ -1,0 +1,164 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package it.geosolutions.geoserver.rest.decoder.gwc.diskquota;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * Enumerates the various storage units according to the power of two based units (instead of
+ * the more common commercial prefixes, often used but not entirely correct)
+ */
+public enum GWCStorageUnit {
+    /**
+     * Byte
+     */
+    B(BigDecimal.ONE), //
+    /**
+     * Kibibyte (2<sup>10</sup> Bytes)
+     */
+    KiB(B.bytes.multiply(BigDecimal.valueOf(1024))), //
+    /**
+     * Mebibyte (2<sup>20</sup> Bytes)
+     */
+    MiB(KiB.bytes.multiply(BigDecimal.valueOf(1024))), //
+    /**
+     * Gibibyte (2<sup>30</sup> Bytes)
+     */
+    GiB(MiB.bytes.multiply(BigDecimal.valueOf(1024))), //
+    /**
+     * Tebibyte (2<sup>40</sup> Bytes)
+     */
+    TiB(GiB.bytes.multiply(BigDecimal.valueOf(1024))), //
+    /**
+     * Pebibyte (2<sup>50</sup> Bytes)
+     */
+    PiB(TiB.bytes.multiply(BigDecimal.valueOf(1024))), //
+    /**
+     * Exibyte (2<sup>60</sup> Bytes)
+     */
+    EiB(PiB.bytes.multiply(BigDecimal.valueOf(1024))), //
+    /**
+     * Zebibyte (2<sup>70</sup> Bytes)
+     */
+    ZiB(EiB.bytes.multiply(BigDecimal.valueOf(1024))),
+    /**
+     * Yobibyte (2<sup>80</sup> Bytes)
+     */
+    YiB(ZiB.bytes.multiply(BigDecimal.valueOf(1024)));
+
+    private final BigDecimal bytes;
+
+    private GWCStorageUnit(final BigDecimal bytes) {
+        this.bytes = bytes;
+    }
+
+    public final BigInteger toBytes(double value) {
+        return toBytes(BigDecimal.valueOf(value));
+    }
+
+    public final BigInteger toBytes(BigDecimal value) {
+        BigDecimal toBytes = bytes.multiply(value);
+        return toBytes.toBigInteger();
+    }
+
+    public final BigDecimal fromBytes(BigInteger value) {
+        return new BigDecimal(value).divide(bytes);
+    }
+
+    public BigDecimal convertTo(double value, GWCStorageUnit target) {
+        return convertTo(BigDecimal.valueOf(value), target);
+    }
+
+    public final BigDecimal convertTo(BigDecimal value, GWCStorageUnit target) {
+        return target.fromBytes(toBytes(value));
+    }
+
+    /**
+     * Returns the most appropriate storage unit to represent the given amount
+     * 
+     * @param value
+     * @param units
+     * @return
+     */
+    public static GWCStorageUnit bestFit(double value, GWCStorageUnit units) {
+        return bestFit(BigDecimal.valueOf(value), units);
+    }
+
+    /**
+     * Returns the most appropriate storage unit to represent the given amount
+     * 
+     * @param value
+     * @param units
+     * @return
+     */
+    public static GWCStorageUnit bestFit(BigDecimal value, GWCStorageUnit units) {
+        BigDecimal bytes = new BigDecimal(units.toBytes(value));
+        // use compareTo because BigDecimal.equals does not consider 1.0 and 1.00 to be equal, so
+        // can't do, for example, bytes.min(TiB.bytes).equals(YiB.bytes)
+        if (bytes.compareTo(YiB.bytes) >= 0) {
+            return YiB;
+        }
+        if (bytes.compareTo(ZiB.bytes) >= 0) {
+            return ZiB;
+        }
+        if (bytes.compareTo(EiB.bytes) >= 0) {
+            return EiB;
+        }
+        if (bytes.compareTo(PiB.bytes) >= 0) {
+            return PiB;
+        }
+        if (bytes.compareTo(TiB.bytes) >= 0) {
+            return TiB;
+        }
+        if (bytes.compareTo(GiB.bytes) >= 0) {
+            return GiB;
+        }
+        if (bytes.compareTo(MiB.bytes) >= 0) {
+            return MiB;
+        }
+        if (bytes.compareTo(KiB.bytes) >= 0) {
+            return KiB;
+        }
+
+        return B;
+    }
+
+    public static GWCStorageUnit bestFit(BigInteger bytes) {
+        return bestFit(new BigDecimal(bytes), B);
+    }
+
+    /**
+     * Returns {@code MB} instead of {@code MiB}, {@code GB} instead of {@code GiB}, etc.
+     */
+    public String toNiceString() {
+        String s = toString();
+        if (B == this) {
+            return s;
+        }
+
+        return new StringBuilder().append(s.charAt(0)).append(s.charAt(2)).toString();
+    }
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/masstruncate/MassTruncateRequests.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/masstruncate/MassTruncateRequests.java
@@ -1,0 +1,61 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package it.geosolutions.geoserver.rest.decoder.gwc.masstruncate;
+
+import it.geosolutions.geoserver.rest.Util;
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import java.util.List;
+import org.jdom.Element;
+
+/**
+ * @author Nazzareno Sileno - CNR IMAA geoSDI Group
+ * @email nazzareno.sileno@geosdi.org
+ */
+public class MassTruncateRequests {
+
+    private final Element massTruncateRequestsElem;
+
+    public static MassTruncateRequests build(String response) {
+        if (response == null) {
+            return null;
+        }
+
+        Element pb = JDOMBuilder.buildElement(response);
+        if (pb != null) {
+            return new MassTruncateRequests(pb);
+        } else {
+            return null;
+        }
+    }
+
+    public MassTruncateRequests(Element massTruncateRequestsElem) {
+        this.massTruncateRequestsElem = massTruncateRequestsElem;
+    }
+
+    public List<String> getRequestTypes() {
+        return Util.getElementsChildrenContent(massTruncateRequestsElem, "requestType");
+    }
+
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/seed/GWCTruncateSeedType.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/seed/GWCTruncateSeedType.java
@@ -1,0 +1,35 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package it.geosolutions.geoserver.rest.decoder.gwc.seed;
+
+/**
+ * @author Nazzareno Sileno - CNR IMAA geoSDI Group
+ * @email nazzareno.sileno@geosdi.org
+ */
+public enum GWCTruncateSeedType {
+    
+    all, running, pending;
+
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/seed/GlobalSeedStatus.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/seed/GlobalSeedStatus.java
@@ -1,0 +1,49 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package it.geosolutions.geoserver.rest.decoder.gwc.seed;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+/**
+ * @author Nazzareno Sileno - CNR IMAA geoSDI Group
+ * @email nazzareno.sileno@geosdi.org
+ */
+public class GlobalSeedStatus {
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty("long-array-array")
+    private List<SeedStatus> elements = new ArrayList<SeedStatus>();
+
+    public List<SeedStatus> getElements() {
+        return elements;
+    }
+
+//    public void setElements(List<SeedStatus> elements) {
+//        this.elements = elements;
+//    }
+
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/seed/SeedStatus.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/seed/SeedStatus.java
@@ -1,0 +1,103 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest.decoder.gwc.seed;
+
+import java.util.ArrayList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Nazzareno Sileno - CNR IMAA geoSDI Group
+ * @email nazzareno.sileno@geosdi.org
+ */
+public class SeedStatus extends ArrayList<Long> {
+    private static final long serialVersionUID = -5774790742826850888L;
+    private final static Logger LOGGER = LoggerFactory.getLogger(SeedStatus.class);
+
+    public enum GWCSeedTaskStatus{
+        ABORTED(-1), PENDING(0), RUNNING(1), DONE(2), NOT_FOUND(999);
+
+        private final long statusCode;
+        
+        private GWCSeedTaskStatus(long statusCode) {
+            this.statusCode = statusCode;
+        }
+
+        public long getStatusCode() {
+            return statusCode;
+        }
+        
+        public static GWCSeedTaskStatus getTaskStatus(int value){
+//            LOGGER.debug("Value to search for task: " + value);
+            switch(value){
+                case -1: return ABORTED;
+                case 0: return PENDING;
+                case 1: return RUNNING;
+                case 2: return DONE;
+                default: return NOT_FOUND;
+            }
+        }
+    }
+    
+    public long getTilesProcessed(){
+        return super.get(0);
+    }
+    
+    /**
+     * 
+     * @return The total number of tiles to process
+     */
+    public long getTotalNumOfTilesToProcess(){
+        return super.get(1);
+    }
+    
+    /**
+     * 
+     * @return The expected remaining time in seconds
+     */
+    public long getExpectedRemainingTime(){
+        return super.get(2);
+    }
+
+    /**
+     * 
+     * @return The task ID
+     */
+    public long getTaskID(){
+        return super.get(3);
+    }
+
+    /**
+     * 
+     * @return The task status. The meaning of the Task status field is: 
+     * -1 = ABORTED, 0 = PENDING, 1 = RUNNING, 2 = DONE
+     */
+    public GWCSeedTaskStatus getTaskStatus(){
+        return GWCSeedTaskStatus.getTaskStatus(
+                super.get(4) != null ? super.get(4).intValue() : 999);
+    }
+    
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/statistics/GWCInMemoryCacheStatistics.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/statistics/GWCInMemoryCacheStatistics.java
@@ -1,0 +1,227 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package it.geosolutions.geoserver.rest.decoder.gwc.statistics;
+
+import java.io.Serializable;
+
+/**
+ * This class is a container of all the Statistics of the CacheProvider object 
+ * used by the MemoryBlobStore.
+ * 
+ * @author Nicola Lagomarsini, GeoSolutions
+ * 
+ */
+public class GWCInMemoryCacheStatistics implements Serializable {
+
+    /** serialVersionUID */
+    private static final long serialVersionUID = -1049287017217353112L;
+
+    /** Cache hit count */
+    private long hitCount = 0;
+
+    /** Cache miss count */
+    private long missCount = 0;
+
+    /** Cache eviction count */
+    private long evictionCount = 0;
+
+    /** Cache total request count (hit + miss) */
+    private long totalCount = 0;
+
+    /** Cache hit rate */
+    private double hitRate = 0;
+
+    /** Cache miss rate */
+    private double missRate = 0;
+
+    /** Cache current memory occupation */
+    private double currentMemoryOccupation = 0;
+
+    /** Cache total size */
+    private long totalSize = 0;
+
+    /** Cache actual size */
+    private long actualSize = 0;
+
+    public GWCInMemoryCacheStatistics() {
+    }
+
+    // Copy Constructor
+    public GWCInMemoryCacheStatistics(GWCInMemoryCacheStatistics stats) {
+        this.setEvictionCount(stats.getEvictionCount());
+        this.setHitCount(stats.getHitCount());
+        this.setMissCount(stats.getMissCount());
+        this.setTotalCount(stats.getRequestCount());
+        this.setHitRate(stats.getHitRate());
+        this.setMissRate(stats.getMissRate());
+        this.setCurrentMemoryOccupation(stats.getCurrentMemoryOccupation());
+        this.setActualSize(stats.getActualSize());
+        this.setTotalSize(stats.getTotalSize());
+    }
+
+    /**
+     * @return the cache hit count
+     */
+    public long getHitCount() {
+        return hitCount;
+    }
+
+    /**
+     * Setter for cache hit count
+     * 
+     * @param hitCount
+     */
+    public void setHitCount(long hitCount) {
+        this.hitCount = hitCount;
+    }
+
+    /**
+     * @return the cache miss count
+     */
+    public long getMissCount() {
+        return missCount;
+    }
+
+    /**
+     * Setter for cache miss count
+     * 
+     * @param missCount
+     */
+    public void setMissCount(long missCount) {
+        this.missCount = missCount;
+    }
+
+    /**
+     * @return the cache eviction count
+     */
+    public long getEvictionCount() {
+        return evictionCount;
+    }
+
+    /**
+     * Setter for cache eviction count
+     * 
+     * @param evictionCount
+     */
+    public void setEvictionCount(long evictionCount) {
+        this.evictionCount = evictionCount;
+    }
+
+    /**
+     * @return the cache total request count
+     */
+    public long getRequestCount() {
+        return totalCount;
+    }
+
+    /**
+     * Setter for cache total count
+     * 
+     * @param totalCount
+     */
+    public void setTotalCount(long totalCount) {
+        this.totalCount = totalCount;
+    }
+
+    /**
+     * @return the cache hit rate
+     */
+    public double getHitRate() {
+        return hitRate;
+    }
+
+    /**
+     * Setter for cache hit rate
+     * 
+     * @param hitRate
+     */
+    public void setHitRate(double hitRate) {
+        this.hitRate = hitRate;
+    }
+
+    /**
+     * @return the cache miss rate
+     */
+    public double getMissRate() {
+        return missRate;
+    }
+
+    /**
+     * Setter for cache miss rate
+     * 
+     * @param missRate
+     */
+    public void setMissRate(double missRate) {
+        this.missRate = missRate;
+    }
+
+    /**
+     * @return the cache current memory occupation
+     */
+    public double getCurrentMemoryOccupation() {
+        return currentMemoryOccupation;
+    }
+
+    /**
+     * Setter for cache memory occupation
+     * 
+     * @param currentMemoryOccupation
+     */
+    public void setCurrentMemoryOccupation(double currentMemoryOccupation) {
+        this.currentMemoryOccupation = currentMemoryOccupation;
+    }
+
+    /**
+     * @return the cache current total size
+     */
+    public long getTotalSize() {
+        return totalSize;
+    }
+
+    /**
+     * Setter for cache total size
+     * 
+     * @param totalSize
+     */
+    public void setTotalSize(long totalSize) {
+        this.totalSize = totalSize;
+    }
+
+    /**
+     * @return the cache current actual size
+     */
+    public long getActualSize() {
+        return actualSize;
+    }
+
+    /**
+     * Setter for cache actual size
+     * 
+     * @param actualSize
+     */
+    public void setActualSize(long actualSize) {
+        this.actualSize = actualSize;
+    }
+}

--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/statistics/GWCInMemoryCacheStatisticsXML.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/gwc/statistics/GWCInMemoryCacheStatisticsXML.java
@@ -1,0 +1,124 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package it.geosolutions.geoserver.rest.decoder.gwc.statistics;
+
+import it.geosolutions.geoserver.rest.Util;
+import it.geosolutions.geoserver.rest.decoder.utils.JDOMBuilder;
+import java.io.Serializable;
+import org.jdom.Element;
+
+/**
+ * This class is a container of all the Statistics of the CacheProvider object
+ * used by the MemoryBlobStore.
+ * 
+ * @author Nazzareno Sileno - CNR IMAA geoSDI Group
+ */
+public class GWCInMemoryCacheStatisticsXML implements Serializable {
+
+    private static final long serialVersionUID = 7000603154441802797L;
+
+    private final Element inMemoryCacheStatisticsElem;
+
+    public static GWCInMemoryCacheStatisticsXML build(String response) {
+        if (response == null) {
+            return null;
+        }
+
+        Element pb = JDOMBuilder.buildElement(response);
+        if (pb != null) {
+            return new GWCInMemoryCacheStatisticsXML(pb);
+        } else {
+            return null;
+        }
+    }
+
+    public GWCInMemoryCacheStatisticsXML(Element inMemoryCacheStatisticsElem) {
+        this.inMemoryCacheStatisticsElem = inMemoryCacheStatisticsElem;
+    }
+
+    /**
+     * @return the cache hit count
+     */
+    public Long getHitCount() {
+        return Util.getLongValueFromText(this.inMemoryCacheStatisticsElem.getChildText("hitCount"));
+    }
+
+    /**
+     * @return the cache miss count
+     */
+    public Long getMissCount() {
+        return Util.getLongValueFromText(this.inMemoryCacheStatisticsElem.getChildText("missCount"));
+    }
+
+    /**
+     * @return the cache eviction count
+     */
+    public Long getEvictionCount() {
+        return Util.getLongValueFromText(this.inMemoryCacheStatisticsElem.getChildText("evictionCount"));
+    }
+
+    /**
+     * @return the cache total request count
+     */
+    public Long getRequestCount() {
+        return Util.getLongValueFromText(this.inMemoryCacheStatisticsElem.getChildText("totalCount"));
+    }
+
+    /**
+     * @return the cache hit rate
+     */
+    public Double getHitRate() {
+        return Util.getDoubleValueFromText(this.inMemoryCacheStatisticsElem.getChildText("hitRate"));
+    }
+
+    /**
+     * @return the cache miss rate
+     */
+    public Double getMissRate() {
+        return Util.getDoubleValueFromText(this.inMemoryCacheStatisticsElem.getChildText("missRate"));
+    }
+
+    /**
+     * @return the cache current memory occupation
+     */
+    public Double getCurrentMemoryOccupation() {
+        return Util.getDoubleValueFromText(this.inMemoryCacheStatisticsElem.getChildText("currentMemoryOccupation"));
+    }
+
+    /**
+     * @return the cache current total size
+     */
+    public Long getTotalSize() {
+        return Util.getLongValueFromText(this.inMemoryCacheStatisticsElem.getChildText("totalSize"));
+    }
+
+    /**
+     * @return the cache current actual size
+     */
+    public Long getActualSize() {
+        return Util.getLongValueFromText(this.inMemoryCacheStatisticsElem.getChildText("actualSize"));
+    }
+
+}

--- a/src/test/java/it/geosolutions/geoserver/rest/GeoWebCacheRESTTest.java
+++ b/src/test/java/it/geosolutions/geoserver/rest/GeoWebCacheRESTTest.java
@@ -1,0 +1,161 @@
+/*
+ *  GeoServer-Manager - Simple Manager Library for GeoServer
+ *  
+ *  Copyright (C) 2007,2011 GeoSolutions S.A.S.
+ *  http://www.geo-solutions.it
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package it.geosolutions.geoserver.rest;
+
+import it.geosolutions.geoserver.rest.decoder.gwc.GWCRESTWMSLayer;
+import java.net.MalformedURLException;
+import java.net.URL;
+import junit.framework.Assert;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Initializes REST params.
+ * <P>
+ * <B>These tests are destructive, so you have to explicitly enable them</B> by setting the env var <TT>resttest</TT> to <TT>true</TT>.
+ * <P>
+ * The target geoserver instance can be customized by defining the following env vars:
+ * <ul>
+ * <LI><TT>resturl</TT> (default <TT>http://localhost:8080/geowebcache</TT>)</LI>
+ * <LI><TT>restuser</TT> (default: <TT>geowebcache</TT>)</LI>
+ * <LI><TT>restpw</TT> (default: <TT>secured</TT>)</LI>
+ * </ul>
+ * 
+ * @author Nazzareno Sileno - CNR IMAA geoSDI Group
+ * @email nazzareno.sileno@geosdi.org
+ */
+public class GeoWebCacheRESTTest {
+    private final static Logger LOGGER = LoggerFactory.getLogger(GeoWebCacheRESTTest.class);
+
+    @Rule
+    public TestName _testName = new TestName();
+
+    public static final String RESTURL;
+
+    public static final String RESTUSER;
+
+    public static final String RESTPW;
+
+    // geowebcache target version
+//    public static final String GWC_VERSION;
+
+    public static URL URL;
+
+    public static GeoWebCacheRESTManager geoWebCache;
+    
+    private static boolean enabled = false;
+
+    private static Boolean existgwc = null;
+
+    static {
+        RESTURL = getenv("gwcmgr_resturl", "http://localhost:8989/geowebcache");
+        RESTUSER = getenv("gwcmgr_restuser", "geowebcache");
+        RESTPW = getenv("gwcmgr_restpw", "secured");
+//        GWC_VERSION = getenv("gwcmgr_version", "1.8.0");
+
+        // These tests will destroy data, so let's make sure we do want to run them
+        enabled = getenv("gwcmgr_resttest", "false").equalsIgnoreCase("true");
+        if (!enabled)
+            LOGGER.warn("Tests are disabled. Please read the documentation to enable them.");
+
+        try {
+            URL = new URL(RESTURL);
+            geoWebCache = new GeoWebCacheRESTManager(RESTURL, RESTUSER, RESTPW);
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static String getenv(String envName, String envDefault) {
+        String env = System.getenv(envName);
+        String prop = System.getProperty(envName, env);
+        LOGGER.debug("varname " + envName + " --> env:" + env + " prop:"+prop);
+        return prop != null ? prop : envDefault;
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+
+        if (enabled) {
+            if (existgwc == null) {
+                existgwc = geoWebCache.existGeoWebCache();
+                if (!existgwc) {
+                    LOGGER.error("TESTS WILL FAIL BECAUSE NO GEOWEBCACHE WAS FOUND AT " + RESTURL
+                            + " (" + RESTUSER + ":" + RESTPW + ")");
+                } else {
+                    LOGGER.info("Using geowebcache instance " + RESTUSER + ":" + RESTPW + " @ "
+                            + RESTURL);
+                }
+            } else if (existgwc == false){
+                System.out.println("Failing tests : geowebcache not found");
+                fail("GeoWebCache not found");
+            }
+            
+        } else {
+            System.out.println("Skipping tests ");
+            LOGGER.warn("Tests are disabled. Please read the documentation to enable them.");
+        }
+    }
+
+    @Before
+    public void before(){
+        String testName = _testName.getMethodName();
+        LOGGER.warn("");
+        LOGGER.warn("============================================================");
+        LOGGER.warn("=== RUNNING TEST " + testName);
+        LOGGER.warn("");
+    }
+
+    protected boolean enabled() {
+        return enabled;
+    }
+    
+    
+    @Test
+    public void testGWCExistence(){
+        LOGGER.debug("Testing GWC Existence");
+        Assert.assertTrue("The GeoWebCache is unreachable", geoWebCache.existGeoWebCache());
+    }
+
+    @Test
+    public void testGWCGetLayer(){
+        LOGGER.debug("Testing GWC GetLayer");
+        GWCRESTWMSLayer layer = geoWebCache.getLayer("img states");
+        Assert.assertNotNull("Please, ensure that the 'img states' default layer is available", layer);
+        Assert.assertEquals("img states", layer.getName());
+        Assert.assertEquals("Nicer title for Image States", layer.getTitle());
+        Assert.assertEquals(4, layer.getMimeFormats().size());
+        LOGGER.info("Testing GWC GetLayer result: " + geoWebCache.getLayer("img states"));
+    }
+
+
+}

--- a/src/test/java/it/geosolutions/geoserver/rest/GeoWebCacheRESTTest.java
+++ b/src/test/java/it/geosolutions/geoserver/rest/GeoWebCacheRESTTest.java
@@ -1,7 +1,7 @@
 /*
  *  GeoServer-Manager - Simple Manager Library for GeoServer
  *  
- *  Copyright (C) 2007,2011 GeoSolutions S.A.S.
+ *  Copyright (C) 2007,2015 GeoSolutions S.A.S.
  *  http://www.geo-solutions.it
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,13 +22,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package it.geosolutions.geoserver.rest;
 
 import it.geosolutions.geoserver.rest.decoder.gwc.GWCRESTWMSLayer;
+import it.geosolutions.geoserver.rest.decoder.gwc.diskquota.GWCExpirationPolicy;
+import it.geosolutions.geoserver.rest.decoder.gwc.diskquota.GWCQuotaConfiguration;
+import it.geosolutions.geoserver.rest.decoder.gwc.masstruncate.MassTruncateRequests;
+import it.geosolutions.geoserver.rest.decoder.gwc.seed.GWCTruncateSeedType;
+import it.geosolutions.geoserver.rest.decoder.gwc.seed.GlobalSeedStatus;
+import it.geosolutions.geoserver.rest.decoder.gwc.statistics.GWCInMemoryCacheStatisticsXML;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.concurrent.TimeUnit;
 import junit.framework.Assert;
+import org.apache.commons.io.IOUtils;
+import org.codehaus.jackson.map.JsonMappingException;
 import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -37,23 +48,30 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
 
 /**
  * Initializes REST params.
  * <P>
- * <B>These tests are destructive, so you have to explicitly enable them</B> by setting the env var <TT>resttest</TT> to <TT>true</TT>.
+ * <B>These tests are destructive, so you have to explicitly enable them</B> by
+ * setting the env var <TT>resttest</TT> to <TT>true</TT>.
  * <P>
- * The target geoserver instance can be customized by defining the following env vars:
+ * The target geoserver instance can be customized by defining the following env
+ * vars:
  * <ul>
- * <LI><TT>resturl</TT> (default <TT>http://localhost:8080/geowebcache</TT>)</LI>
+ * <LI><TT>resturl</TT> (default
+ * <TT>http://localhost:8080/geowebcache</TT>)</LI>
  * <LI><TT>restuser</TT> (default: <TT>geowebcache</TT>)</LI>
  * <LI><TT>restpw</TT> (default: <TT>secured</TT>)</LI>
  * </ul>
- * 
+ * Maven command execution: mvn test -Dtest=GeoWebCacheRESTTest
+ * -Dgwcmgr_resttest=true
+ *
  * @author Nazzareno Sileno - CNR IMAA geoSDI Group
  * @email nazzareno.sileno@geosdi.org
  */
 public class GeoWebCacheRESTTest {
+
     private final static Logger LOGGER = LoggerFactory.getLogger(GeoWebCacheRESTTest.class);
 
     @Rule
@@ -67,11 +85,10 @@ public class GeoWebCacheRESTTest {
 
     // geowebcache target version
 //    public static final String GWC_VERSION;
-
     public static URL URL;
 
     public static GeoWebCacheRESTManager geoWebCache;
-    
+
     private static boolean enabled = false;
 
     private static Boolean existgwc = null;
@@ -84,8 +101,9 @@ public class GeoWebCacheRESTTest {
 
         // These tests will destroy data, so let's make sure we do want to run them
         enabled = getenv("gwcmgr_resttest", "false").equalsIgnoreCase("true");
-        if (!enabled)
+        if (!enabled) {
             LOGGER.warn("Tests are disabled. Please read the documentation to enable them.");
+        }
 
         try {
             URL = new URL(RESTURL);
@@ -98,7 +116,7 @@ public class GeoWebCacheRESTTest {
     private static String getenv(String envName, String envDefault) {
         String env = System.getenv(envName);
         String prop = System.getProperty(envName, env);
-        LOGGER.debug("varname " + envName + " --> env:" + env + " prop:"+prop);
+        LOGGER.debug("varname " + envName + " --> env:" + env + " prop:" + prop);
         return prop != null ? prop : envDefault;
     }
 
@@ -115,11 +133,11 @@ public class GeoWebCacheRESTTest {
                     LOGGER.info("Using geowebcache instance " + RESTUSER + ":" + RESTPW + " @ "
                             + RESTURL);
                 }
-            } else if (existgwc == false){
+            } else if (existgwc == false) {
                 System.out.println("Failing tests : geowebcache not found");
                 fail("GeoWebCache not found");
             }
-            
+
         } else {
             System.out.println("Skipping tests ");
             LOGGER.warn("Tests are disabled. Please read the documentation to enable them.");
@@ -127,7 +145,7 @@ public class GeoWebCacheRESTTest {
     }
 
     @Before
-    public void before(){
+    public void before() {
         String testName = _testName.getMethodName();
         LOGGER.warn("");
         LOGGER.warn("============================================================");
@@ -138,24 +156,330 @@ public class GeoWebCacheRESTTest {
     protected boolean enabled() {
         return enabled;
     }
-    
-    
+
     @Test
-    public void testGWCExistence(){
+    public void testGWCExistence() {
         LOGGER.debug("Testing GWC Existence");
         Assert.assertTrue("The GeoWebCache is unreachable", geoWebCache.existGeoWebCache());
     }
 
+    // <editor-fold desc="/masstruncate" defaultstate="collapsed">
+    //==========================================================================
+    //=== MASSTRUNCATE 
+    //==========================================================================
     @Test
-    public void testGWCGetLayer(){
+    public void testMassTruncate() throws InterruptedException, IOException {
+        File layerFile = new ClassPathResource("testdata/geowebcache/layer2.xml").getFile();
+        final String layerName = "layer2";
+        cleanupTestLayer(layerName);
+        Assert.assertTrue(geoWebCache.addLayer(layerFile, layerName));
+        File seedRequestFile = new ClassPathResource("testdata/geowebcache/seedRequest.xml").getFile();
+        Assert.assertTrue("Failed to add seedRequest",
+                geoWebCache.addSeedRequest(seedRequestFile, layerName));
+        LOGGER.info("Waiting 2s before seed truncation");
+        Thread.sleep(2500L);
+        //Truncation
+        Assert.assertTrue(geoWebCache.truncateSeedRequestTask(layerName, GWCTruncateSeedType.all));
+
+        Assert.assertTrue(geoWebCache.truncateLayer(layerName));
+        LOGGER.info("Waiting 2s before removing layer");
+        Thread.sleep(2500L);
+        Assert.assertTrue(geoWebCache.removeLayer(layerName));
+    }
+
+    @Test
+    public void testGetMassTruncateReqAvailable() throws InterruptedException, IOException {
+        MassTruncateRequests massTruncateRequests = geoWebCache.getMassTruncateReqAvailable();
+        Assert.assertNotNull("The mass truncate request is not available", massTruncateRequests);
+        Assert.assertNotNull(massTruncateRequests.getRequestTypes());
+        Assert.assertEquals(1, massTruncateRequests.getRequestTypes().size());
+        Assert.assertEquals("truncateLayer", massTruncateRequests.getRequestTypes().get(0));
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="/diskquota" defaultstate="collapsed">
+    //==========================================================================
+    //=== DISKQUOTA
+    //==========================================================================
+    @Test
+    public void testChangeDiskQuotaConfig() throws JsonMappingException {
+        GWCQuotaConfiguration quotaConfiguration = geoWebCache.getCurrentDiskQuotaConfig();
+        int maxConcurrentCleanUps = quotaConfiguration.getMaxConcurrentCleanUps();
+        LOGGER.info("Quota maxConcurrentCleanUps: " + maxConcurrentCleanUps);
+        quotaConfiguration.setMaxConcurrentCleanUps(maxConcurrentCleanUps + 1);
+        geoWebCache.changeDiskQuotaConfig(quotaConfiguration);
+        //After update
+        quotaConfiguration = geoWebCache.getCurrentDiskQuotaConfig();
+        //After retrieve new config
+        Assert.assertEquals(maxConcurrentCleanUps + 1,
+                (int) quotaConfiguration.getMaxConcurrentCleanUps());
+        quotaConfiguration.setMaxConcurrentCleanUps(maxConcurrentCleanUps);
+        //Re-update
+        geoWebCache.changeDiskQuotaConfig(quotaConfiguration);
+        //After retrieve new config
+        quotaConfiguration = geoWebCache.getCurrentDiskQuotaConfig();
+        Assert.assertEquals(maxConcurrentCleanUps,
+                (int) quotaConfiguration.getMaxConcurrentCleanUps());
+    }
+
+    @Test
+    public void testCurrentDiskQuotaConfiguration() throws JsonMappingException {
+        GWCQuotaConfiguration quotaConfiguration = geoWebCache.getCurrentDiskQuotaConfig();
+        LOGGER.info("Quota configuration: " + quotaConfiguration);
+        Assert.assertNotNull(quotaConfiguration);
+        Assert.assertEquals(GWCExpirationPolicy.LFU, quotaConfiguration.getGlobalExpirationPolicyName());
+        Assert.assertEquals(2, (int) quotaConfiguration.getMaxConcurrentCleanUps());
+        Assert.assertEquals(10, (int) quotaConfiguration.getCacheCleanUpFrequency());
+        Assert.assertNotNull(quotaConfiguration.getGlobalQuota());
+        Assert.assertNotNull(quotaConfiguration.getGlobalQuota().getBytes());
+//        LOGGER.info("Quota configuration: " + quotaConfiguration.getGlobalQuota().getBytes());
+        Assert.assertEquals(TimeUnit.SECONDS, quotaConfiguration.getCacheCleanUpUnits());
+        Assert.assertFalse(quotaConfiguration.isEnabled());
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="/seed" defaultstate="collapsed">
+    //==========================================================================
+    //=== SEED
+    //==========================================================================
+    @Test
+    public void testGlobalSeedingStatus() throws JsonMappingException {
+        GlobalSeedStatus globalSeedingStatus = geoWebCache.getGlobalSeedingStatus();
+        if (globalSeedingStatus != null && globalSeedingStatus.getElements() != null
+                && !globalSeedingStatus.getElements().isEmpty()) {
+            LOGGER.info("Result global seeding status: " + globalSeedingStatus.getElements().get(0).getTaskStatus());
+            Assert.assertNotNull(globalSeedingStatus.getElements().get(0).getExpectedRemainingTime());
+            Assert.assertNotNull(globalSeedingStatus.getElements().get(0).getTaskID());
+            Assert.assertNotNull(globalSeedingStatus.getElements().get(0).getTaskStatus());
+            Assert.assertNotNull(globalSeedingStatus.getElements().get(0).getTilesProcessed());
+            Assert.assertNotNull(globalSeedingStatus.getElements().get(0).getTotalNumOfTilesToProcess());
+        }
+    }
+
+    @Test
+    public void testTruncateSeedingRequest() {
+        Assert.assertTrue(geoWebCache.truncateSeedRequestTask("layer2", GWCTruncateSeedType.all));
+    }
+
+    @Test
+    public void testLayerSeedingStatus() throws JsonMappingException, IOException, InterruptedException {
+        File layerFile = new ClassPathResource("testdata/geowebcache/layer2.xml").getFile();
+        final String layerName = "layer2";
+        cleanupTestLayer(layerName);
+        Assert.assertTrue(geoWebCache.addLayer(layerFile, layerName));
+        File seedRequestFile = new ClassPathResource("testdata/geowebcache/seedRequest.xml").getFile();
+        Assert.assertTrue("Failed to add seedRequest",
+                geoWebCache.addSeedRequest(seedRequestFile, layerName));
+        //
+        GlobalSeedStatus globalSeedingStatus = geoWebCache.getLayerSeedingStatus(layerName);
+        if (globalSeedingStatus != null && globalSeedingStatus.getElements() != null
+                && !globalSeedingStatus.getElements().isEmpty()) {
+            LOGGER.info("Result single layer seeding status: " + globalSeedingStatus.getElements().get(0).getTaskStatus());
+            Assert.assertNotNull(globalSeedingStatus.getElements().get(0).getExpectedRemainingTime());
+            Assert.assertNotNull(globalSeedingStatus.getElements().get(0).getTaskID());
+            Assert.assertNotNull(globalSeedingStatus.getElements().get(0).getTaskStatus());
+            Assert.assertNotNull(globalSeedingStatus.getElements().get(0).getTilesProcessed());
+            Assert.assertNotNull(globalSeedingStatus.getElements().get(0).getTotalNumOfTilesToProcess());
+        }
+        //
+        LOGGER.info("Waiting 2s before seed truncation");
+        Thread.sleep(50000L);
+        Assert.assertTrue(geoWebCache.truncateSeedRequestTask(layerName, GWCTruncateSeedType.all));
+        LOGGER.info("Waiting 2s before removing layer");
+        Thread.sleep(50000L);
+        Assert.assertTrue(geoWebCache.removeLayer(layerName));
+    }
+
+    @Test
+    public void testADDRemoveSeedRequest() throws IOException, InterruptedException {
+        File layerFile = new ClassPathResource("testdata/geowebcache/layer2.xml").getFile();
+        final String layerName = "layer2";
+        cleanupTestLayer(layerName);
+        Assert.assertTrue(geoWebCache.addLayer(layerFile, layerName));
+        File seedRequestFile = new ClassPathResource("testdata/geowebcache/seedRequest.xml").getFile();
+        Assert.assertTrue("Failed to add seedRequest",
+                geoWebCache.addSeedRequest(seedRequestFile, layerName));
+        LOGGER.info("Waiting 2s before seed truncation");
+        Thread.sleep(2500L);
+        Assert.assertTrue(geoWebCache.truncateSeedRequestTask(layerName, GWCTruncateSeedType.all));
+        LOGGER.info("Waiting 2s before removing layer");
+        Thread.sleep(2500L);
+        Assert.assertTrue(geoWebCache.removeLayer(layerName));
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="/statistics" defaultstate="collapsed">
+    //==========================================================================
+    //=== STATISTICS 
+    //==========================================================================
+//    @Test
+    public void testGetCacheStatistics() throws JsonMappingException {
+        /**
+         * NB: the in memory cache statistics if the blobstore used is an
+         * instance of MemoryBlobStore.
+         */
+        GWCInMemoryCacheStatisticsXML statistics = geoWebCache.getInMemoryCacheStatisticsXML();
+        Assert.assertNotNull("Cannot get the in memory cache statistics. "
+                + "Are you sure that you are using the MemoryBlobStore?", statistics);
+        LOGGER.info("In Memory Cache statistics: " + statistics);
+        Assert.assertTrue(statistics.getTotalSize() > 0);
+        Assert.assertTrue(statistics.getActualSize() > 0);
+        Assert.assertTrue(statistics.getCurrentMemoryOccupation() > 0);
+    }
+    // </editor-fold>
+
+    // <editor-fold desc="/layers" defaultstate="collapsed">
+    //==========================================================================
+    //=== LAYERS
+    //==========================================================================
+    /**
+     * Dummy test to check the gel layer functionality
+     */
+//    @Test
+    public void testGWCGetLayers() {
+        Assert.assertEquals(3, geoWebCache.getLayers().size());
+        Assert.assertEquals("img states", geoWebCache.getLayers().get(0).getName());
+    }
+
+    @Test
+    public void testAddRemoveResource() throws IOException {
+        File layerFile = new ClassPathResource("testdata/geowebcache/layer.xml").getFile();
+        final String layerName = "layer1";
+        // known state?
+        cleanupTestLayer(layerName);
+        int layersSize = geoWebCache.getLayers().size();
+
+        // test insert
+        String layerContent = IOUtils.toString(new FileInputStream(layerFile));
+        Assert.assertTrue("Failed to add layer", geoWebCache.addLayer(layerContent, layerName));
+        Assert.assertEquals(layersSize + 1, geoWebCache.getLayers().size());
+        //Removing test layer
+        Assert.assertTrue("The layer was not removed", geoWebCache.removeLayer(layerName));
+        Assert.assertEquals(layersSize, geoWebCache.getLayers().size());
+    }
+
+    @Test
+    public void testAddRemoveFile() throws IOException {
+        File layerFile = new ClassPathResource("testdata/geowebcache/layer.xml").getFile();
+        // known state?
+        final String layerName = "layer1";
+        cleanupTestLayer(layerName);
+        int layersSize = geoWebCache.getLayers().size();
+        Assert.assertTrue("Failed to add layer", geoWebCache.addLayer(layerFile, layerName));
+        Assert.assertEquals(layersSize + 1, geoWebCache.getLayers().size());
+        //Removing test layer
+        Assert.assertTrue("The layer was not removed", geoWebCache.removeLayer(layerName));
+        Assert.assertEquals(layersSize, geoWebCache.getLayers().size());
+    }
+
+    @Test
+    public void testAddModifyRemoveFile() throws IOException {
+        File layerFile = new ClassPathResource("testdata/geowebcache/layer.xml").getFile();
+        File modLayerFile = new ClassPathResource("testdata/geowebcache/layerMod.xml").getFile();
+        // known state?
+        final String layerName = "layer1";
+        cleanupTestLayer(layerName);
+        int layersSize = geoWebCache.getLayers().size();
+        Assert.assertTrue("Failed to add layer", geoWebCache.addLayer(layerFile, layerName));
+        Assert.assertFalse("It is not possible to add two times the same layer",
+                geoWebCache.addLayer(layerFile, layerName));
+        Assert.assertTrue("Failed to modify layer", geoWebCache.updateLayer(modLayerFile, layerName));
+        Assert.assertEquals(layersSize + 1, geoWebCache.getLayers().size());
+        //Removing test layer
+        Assert.assertTrue("The layer was not removed", geoWebCache.removeLayer(layerName));
+        Assert.assertEquals(layersSize, geoWebCache.getLayers().size());
+    }
+
+    protected void cleanupTestLayer(final String layerName) {
+        // dry run delete to work in a known state
+        if (geoWebCache.existsLayer(layerName)) {
+            LOGGER.info("Clearing stale test layer " + layerName);
+            boolean ok = geoWebCache.removeLayer(layerName);
+            if (!ok) {
+                fail("Could not unpublish layer " + layerName);
+            }
+        }
+        assertFalse("Cleanup failed", geoWebCache.existsLayer(layerName));
+    }
+
+//    @Test
+//    public void testGWCRemoveLayer() {
+//        Assert.assertEquals(3, geoWebCache.getLayers().size());
+//        LOGGER.info("Removing layer having name: " + geoWebCache.getLayers().get(2).getName());
+//        Assert.assertTrue("The layer was not removed", geoWebCache.removeLayer(geoWebCache.getLayers().get(2).getName()));
+//        Assert.assertEquals(2, geoWebCache.getLayers().size());
+////        Assert.assertEquals("img states", );
+//    }
+
+    @Test
+    public void testGWCRemoveUnexistingLayer() {
+        Assert.assertEquals(3, geoWebCache.getLayers().size());
+        LOGGER.info("Removing layer having name: unexistingLayer");
+        Assert.assertFalse("The layer must not exist", geoWebCache.removeLayer("unexistingLayer"));
+        Assert.assertEquals(3, geoWebCache.getLayers().size());
+//        Assert.assertEquals("img states", );
+    }
+
+    @Test
+    public void testGWCGetLayerIMGStates() {
         LOGGER.debug("Testing GWC GetLayer");
         GWCRESTWMSLayer layer = geoWebCache.getLayer("img states");
         Assert.assertNotNull("Please, ensure that the 'img states' default layer is available", layer);
         Assert.assertEquals("img states", layer.getName());
         Assert.assertEquals("Nicer title for Image States", layer.getTitle());
         Assert.assertEquals(4, layer.getMimeFormats().size());
+        Assert.assertEquals(1, layer.getGridSubsets().size());
+        Assert.assertNotNull(layer.getGridSubsets().get(0));
+        Assert.assertEquals("EPSG:4326", layer.getGridSubsets().get(0).getGridSetName());
+        Assert.assertNotNull(layer.getGridSubsets().get(0).getExtent());
+        Assert.assertNotNull(layer.getGridSubsets().get(0).getExtent().getCoords());
+        Assert.assertEquals(4, layer.getGridSubsets().get(0).getExtent().getCoords().size());
+        Assert.assertNotNull(layer.getExpireCacheList());
+        Assert.assertEquals(1, layer.getExpireCacheList().size());
+        Assert.assertEquals(0, (int) layer.getExpireCacheList().get(0).getMinZoom());
+        Assert.assertEquals(60, (int) layer.getExpireCacheList().get(0).getExpiration());
+        Assert.assertNotNull(layer.getExpireClientsList());
+        Assert.assertEquals(1, layer.getExpireClientsList().size());
+        Assert.assertEquals(0, (int) layer.getExpireClientsList().get(0).getMinZoom());
+        Assert.assertEquals(500, (int) layer.getExpireClientsList().get(0).getExpiration());
+        Assert.assertNotNull(layer.getWmsUrl());
+        Assert.assertEquals(1, layer.getWmsUrl().size());
+//        LOGGER.info("WMS TEXT: " + layer.getWmsUrl().get(0));
+        Assert.assertEquals("http://demo.opengeo.org/geoserver/wms?", layer.getWmsUrl().get(0));
+        Assert.assertEquals("nurc:Img_Sample,topp:states", layer.getWMSLayers());
+        Assert.assertEquals(false, (boolean) layer.getTransparent());
+        Assert.assertEquals("0x0066FF", layer.getBGColor());
         LOGGER.info("Testing GWC GetLayer result: " + geoWebCache.getLayer("img states"));
     }
 
+    @Test
+    public void testGWCGetLayerToppStates() {
+        LOGGER.debug("Testing GWC GetLayer");
+        GWCRESTWMSLayer layer = geoWebCache.getLayer("topp:states");
+        Assert.assertNotNull("Please, ensure that the 'topp:states' default layer is available", layer);
+        Assert.assertEquals("topp:states", layer.getName());
+
+        Assert.assertNotNull(layer.getMimeFormats());
+        Assert.assertEquals(4, layer.getMimeFormats().size());
+        Assert.assertEquals("image/gif", layer.getMimeFormats().get(0));
+        Assert.assertEquals("image/jpeg", layer.getMimeFormats().get(1));
+        Assert.assertEquals("image/png", layer.getMimeFormats().get(2));
+        Assert.assertEquals("image/png8", layer.getMimeFormats().get(3));
+
+        Assert.assertNotNull(layer.getParameterFilters());
+        Assert.assertNotNull(layer.getParameterFilters().getStringParameterFilter());
+        Assert.assertEquals("STYLES", layer.getParameterFilters().getStringParameterFilter().getKey());
+        Assert.assertEquals("population", layer.getParameterFilters().getStringParameterFilter().getDefaultValue());
+        Assert.assertEquals(3, layer.getParameterFilters().getStringParameterFilter().getValues().size());
+        Assert.assertEquals("pophatch", layer.getParameterFilters().getStringParameterFilter().getValues().get(2));
+
+        Assert.assertNotNull(layer.getWmsUrl());
+        Assert.assertEquals(1, layer.getWmsUrl().size());
+//        LOGGER.info("WMS TEXT: " + layer.getWmsUrl().get(0));
+        Assert.assertEquals("http://demo.opengeo.org/geoserver/topp/wms?", layer.getWmsUrl().get(0));
+
+        LOGGER.info("Testing GWC GetLayer result: " + geoWebCache.getLayer("img states"));
+    }
+    // </editor-fold>
 
 }

--- a/src/test/resources/testdata/geowebcache/layer.xml
+++ b/src/test/resources/testdata/geowebcache/layer.xml
@@ -1,0 +1,15 @@
+<wmsLayer>
+  <name>layer1</name>
+  <mimeFormats>
+    <string>image/png</string>
+  </mimeFormats>
+  <gridSubsets>
+    <gridSubset>
+      <gridSetName>EPSG:900913</gridSetName>
+    </gridSubset>
+  </gridSubsets>
+  <wmsUrl>
+    <string>http://localhost:8080/geoserver/wms</string>
+  </wmsUrl>
+  <wmsLayers>topp:states</wmsLayers>
+</wmsLayer>

--- a/src/test/resources/testdata/geowebcache/layer2.xml
+++ b/src/test/resources/testdata/geowebcache/layer2.xml
@@ -1,0 +1,15 @@
+<wmsLayer>
+  <name>layer2</name>
+  <mimeFormats>
+    <string>image/png</string>
+  </mimeFormats>
+  <gridSubsets>
+    <gridSubset>
+      <gridSetName>EPSG:900913</gridSetName>
+    </gridSubset>
+  </gridSubsets>
+  <wmsUrl>
+    <string>http://localhost:8080/geoserver/wms</string>
+  </wmsUrl>
+  <wmsLayers>nurc:Arc_Sample</wmsLayers>
+</wmsLayer>

--- a/src/test/resources/testdata/geowebcache/layerMod.xml
+++ b/src/test/resources/testdata/geowebcache/layerMod.xml
@@ -1,0 +1,20 @@
+<wmsLayer>
+  <name>layer1</name>
+  <mimeFormats>
+    <string>image/png</string>
+    <string>image/jpeg</string>
+    <string>image/gif</string>
+  </mimeFormats>
+  <gridSubsets>
+    <gridSubset>
+      <gridSetName>EPSG:900913</gridSetName>
+    </gridSubset>
+    <gridSubset>
+      <gridSetName>EPSG:4326</gridSetName>
+    </gridSubset>
+  </gridSubsets>
+  <wmsUrl>
+    <string>http://localhost:8080/geoserver/wms</string>
+  </wmsUrl>
+  <wmsLayers>topp:states,nurc:Img_Sample</wmsLayers>
+</wmsLayer>

--- a/src/test/resources/testdata/geowebcache/seedRequest.xml
+++ b/src/test/resources/testdata/geowebcache/seedRequest.xml
@@ -1,0 +1,12 @@
+<seedRequest>
+    <name>layer2</name>
+    <srs>
+        <number>4326</number>
+    </srs>
+    <zoomStart>1</zoomStart>
+    <zoomStop>12</zoomStop>
+    <format>image/png</format>
+    <!-- type can be * seed (add tiles) * reseed (replace tiles) * truncate (remove tiles) -->
+    <type>seed</type>
+    <threadCount>2</threadCount>
+</seedRequest>

--- a/src/test/resources/testdata/geowebcache/truncateRequest.xml
+++ b/src/test/resources/testdata/geowebcache/truncateRequest.xml
@@ -1,0 +1,36 @@
+<seedRequest>
+  <name>layer1</name>
+  <bounds>
+    <coords>
+      <double>-2495667.977678598</double>
+      <double>-2223677.196231552</double>
+      <double>3291070.6104286816</double>
+      <double>959189.3312465074</double>
+    </coords>
+  </bounds>
+
+  <!-- These are listed on http://localhost:8080/geowebcache/demo -->
+  <gridSetId>EPSG:900913</gridSetId>
+  <zoomStart>0</zoomStart>
+  <!-- This will be reduced to 3, since the layer is only defined for 0-3 -->
+  <zoomStop>2</zoomStop>
+  <format>image/png</format>
+
+  <!-- type can be * seed (add tiles) * reseed (replace tiles) * truncate (remove tiles) -->
+  <type>truncate</type>
+
+  <!-- Number of seeding threads to run in parallel.
+       If type == truncate only one thread will be used regardless of this parameter -->
+  <threadCount>1</threadCount>
+  <!-- Parameter filters -->
+  <parameters>
+    <entry>
+      <string>STYLES</string>
+      <string>pophatch</string>
+    </entry>
+    <entry>
+      <string>CQL_FILTER</string>
+      <string>TOTPOP > 10000</string>
+    </entry>
+  </parameters>
+</seedRequest>


### PR DESCRIPTION
The aim of this pull request is to integrate the GeoWebCache API methods inside GeoServerManager.
I mapped all the geowebcache rest methods in a new GeoServerManager component: GeoWebCacheRESTManager.
I tried to do my best in respect to the spirit of the API: "a REST client library to interact with GeoServer; a requirement for this library is to depend as less as possible on external libraries. This library aims at being lean and mean."
I had only the needing to add the light jackson-mapper-asl version to manage the JSON format. It was the only format admissible in some GWT REST calls, ie: 
GET method for /rest/seed/<layer>.json
I added also test files and classes.

I hope that the effort will be appreciate and will be integrate inside the master brach but if there is the needing to change or modify something, please, let me know and I'll do it.