### PR TITLE
Added getSrs()

### DIFF
--- a/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTPublisher.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTPublisher.java
@@ -1152,11 +1152,22 @@ public class GeoServerRESTPublisher {
         }
 
         // config layer props (style, ...)
-        final GSLayerEncoder layerEncoder = new GSLayerEncoder();
-        if (defaultStyle != null && !defaultStyle.isEmpty())
-            layerEncoder.setDefaultStyle(defaultStyle);
+        final GSLayerEncoder layerEncoder = configureDefaultStyle(defaultStyle);
 
         return configureLayer(workspace, datasetName, layerEncoder);
+    }
+
+    private GSLayerEncoder configureDefaultStyle(String defaultStyle) {
+        final GSLayerEncoder layerEncoder = new GSLayerEncoder();
+        if (defaultStyle != null && !defaultStyle.isEmpty()) {
+            if(defaultStyle.indexOf(":") != -1) {
+                String[] wsAndName = defaultStyle.split(":");
+                layerEncoder.setDefaultStyle(wsAndName[0], wsAndName[1]);
+            } else {
+                layerEncoder.setDefaultStyle(defaultStyle);
+            }
+        }
+        return layerEncoder;
     }
 
     /**
@@ -1621,8 +1632,7 @@ public class GeoServerRESTPublisher {
         }
 
         // config layer props (style, ...)
-        final GSLayerEncoder layerEncoder = new GSLayerEncoder();
-        layerEncoder.setDefaultStyle(defaultStyle);
+        final GSLayerEncoder layerEncoder = configureDefaultStyle(defaultStyle);
 
         return configureLayer(workspace, coverageName, layerEncoder);
     }

--- a/src/main/java/it/geosolutions/geoserver/rest/encoder/GSLayerEncoder.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/encoder/GSLayerEncoder.java
@@ -74,9 +74,11 @@ public class GSLayerEncoder extends PropertyXMLEncoder {
 	
 	public final static String STYLES = "styles";
 	public final static String AUTHORITY_URLS="authorityURLs";
-	public final static String IDENTIFIERS="identifiers"; 
+	public final static String IDENTIFIERS="identifiers";
+	public final static String DEFAULT_STYLE = "defaultStyle";
 	
 	final private Element stylesEncoder = new Element(STYLES);
+	final private Element defaultStyleEncoder = new Element(DEFAULT_STYLE);
 	final private Element authorityURLListEncoder = new Element(AUTHORITY_URLS);
 	final private Element identifierListEncoder = new Element(IDENTIFIERS);
 	
@@ -164,6 +166,20 @@ public class GSLayerEncoder extends PropertyXMLEncoder {
     protected void addDefaultStyle(String defaultStyle) {
         add("defaultStyle", defaultStyle);
     }
+    
+    /**
+     * @see {@link GSLayerEncoder#setDefaultStyle(String)}
+     * @param defaultStyle 
+     */
+    protected void addDefaultStyle(String workspace, String defaultStyle) {
+        addContent(defaultStyleEncoder);
+        Element el = new Element("name");
+        el.setText(defaultStyle);
+        defaultStyleEncoder.addContent(el);
+        el = new Element("workspace");
+        el.setText(workspace);
+        defaultStyleEncoder.addContent(el);
+    }
 
     /**
      * @param defaultStyle The style that will be applied if no style is specified.
@@ -173,6 +189,15 @@ public class GSLayerEncoder extends PropertyXMLEncoder {
         if (defaultStyle==null || defaultStyle.isEmpty())
             throw new IllegalArgumentException("Unable to set an empty or null parameter");
         set("defaultStyle", defaultStyle);
+    }
+    
+    /**
+     * @see {@link GSLayerEncoder#setDefaultStyle(String)}
+     * @param defaultStyle 
+     */
+    public void setDefaultStyle(String workspace, String defaultStyle) {
+        remove("defaultStyle");
+        addDefaultStyle(workspace, defaultStyle);
     }
     
 	/**

--- a/src/main/java/it/geosolutions/geoserver/rest/manager/GeoServerRESTStyleManager.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/manager/GeoServerRESTStyleManager.java
@@ -528,7 +528,7 @@ public class GeoServerRESTStyleManager extends GeoServerRESTAbstractManager {
      */
     public boolean publishStyleInWorkspace(final String workspace, String sldBody) {
         try {
-            return publishStyleInWorkspace(workspace, sldBody);
+            return publishStyleInWorkspace(workspace, sldBody, null);
         } catch (IllegalArgumentException e) {
             if (LOGGER.isErrorEnabled()) {
                 LOGGER.error(e.getLocalizedMessage(), e);

--- a/src/test/java/it/geosolutions/geoserver/rest/encoder/GSLayerEncoderTest.java
+++ b/src/test/java/it/geosolutions/geoserver/rest/encoder/GSLayerEncoderTest.java
@@ -111,4 +111,12 @@ public class GSLayerEncoderTest {
 		Assert.assertEquals("authority1", el.getChild("authority").getValue());
 		Assert.assertEquals("identifier1", el.getChild("identifier").getValue());
 	}
+	
+	@Test
+        public void testDefaultStyleWithWorkspace(){
+	        layerEncoder.setDefaultStyle("ws", "style");
+                Element el = (Element) layerEncoder.getRoot().getChild("defaultStyle");
+                Assert.assertEquals("style", el.getChild("name").getValue());
+                Assert.assertEquals("ws", el.getChild("workspace").getValue());
+        }
 }

--- a/src/test/java/it/geosolutions/geoserver/rest/publisher/GeoserverRESTShapeTest.java
+++ b/src/test/java/it/geosolutions/geoserver/rest/publisher/GeoserverRESTShapeTest.java
@@ -240,6 +240,52 @@ public class GeoserverRESTShapeTest extends GeoserverRESTTest {
         assertTrue("Unpublish() failed", oksld);
         assertFalse(reader.existsStyle(styleName));
     }
+    
+    @Test
+    public void testPublishDeleteStyledInWorkspaceShapeZip() throws FileNotFoundException, IOException {
+        if (!enabled()) {
+            return;
+        }
+        deleteAllWorkspacesRecursively();
+//        Assume.assumeTrue(enabled);
+        assertTrue(publisher.createWorkspace(DEFAULT_WS));
+
+        String ns = "geosolutions";
+        String storeName = "resttestshp";
+        String layerName = "cities";
+        final String styleName = "restteststyle";
+
+        File zipFile = new ClassPathResource("testdata/resttestshp.zip").getFile();
+        publisher.removeDatastore(DEFAULT_WS, storeName,true);
+        publisher.removeStyleInWorkspace(DEFAULT_WS, styleName);
+        
+        File sldFile = new ClassPathResource("testdata/restteststyle.sld").getFile();
+
+        // insert style
+        boolean sldpublished = publisher.publishStyleInWorkspace(DEFAULT_WS, sldFile); // Will take the name from sld contents
+        assertTrue("style publish() failed", sldpublished);
+        assertTrue(reader.existsStyle(DEFAULT_WS, styleName));
+
+        // test insert
+        boolean published = publisher.publishShp(ns, storeName, layerName, zipFile, "EPSG:4326", DEFAULT_WS + ":" + styleName);
+        assertTrue("publish() failed", published);
+        assertTrue(existsLayer(layerName));
+
+        RESTLayer layer = reader.getLayer(layerName);
+//        RESTLayer layerDecoder = new RESTLayer(layer);
+        LOGGER.info("Layer style is " + layer.getDefaultStyle());
+        assertEquals("Style not assigned properly", styleName, layer.getDefaultStyle());
+        assertEquals("Style not assigned properly", DEFAULT_WS, layer.getDefaultStyleWorkspace());
+
+        // remove also datastore
+        boolean dsRemoved = publisher.removeDatastore(ns, storeName,true);
+        assertTrue("removeDatastore() failed", dsRemoved);
+
+        //test delete style
+        boolean oksld = publisher.removeStyleInWorkspace(DEFAULT_WS, styleName);
+        assertTrue("Unpublish() failed", oksld);
+        assertFalse(reader.existsStyle(styleName));
+    }
 
     @Test
     public void testPublishDeleteShapeZipWithParams() throws FileNotFoundException, IOException {


### PR DESCRIPTION
Added getSrs().

Uploading ShapeFile, in some cases, native bounding box crs is something like

GEOGCS["GCS_WGS_1984", DATUM["D_WGS_1984", SPHEROID["WGS_1984", 6378137.0, 298.257223563]], PRIMEM["Greenwich", 0.0], UNIT["degree", 0.017453292519943295], AXIS["Longitude", EAST], AXIS["Latitude", NORTH]]

instead EPSG:3857.

I think this is related to unrecognized native projection of a shapefile.