### PR TITLE
Changed layergroup xml encorer to allow nesting layergroups

### DIFF
--- a/src/main/java/it/geosolutions/geoserver/rest/decoder/RESTResource.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/decoder/RESTResource.java
@@ -136,7 +136,12 @@ public class RESTResource {
     	RESTBoundingBox bbox = this.getLatLonBoundingBox();
     	return bbox.getCRS();
     }
-
+    
+    public String getSrs(){
+        return rootElem.getChildText("srs");
+    }
+    
+    
     public double getMinX() {
         return this.getLatLonBoundingBox().getMinX();
     }

--- a/src/main/java/it/geosolutions/geoserver/rest/encoder/GSLayerGroupEncoder.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/encoder/GSLayerGroupEncoder.java
@@ -61,15 +61,28 @@ public class GSLayerGroupEncoder extends PropertyXMLEncoder {
     }
     
     public void addLayer(String layer, String styleName) {
-        initPublishables("layers");
+        initPublishables("publishables");
+        Element e = elem("published", elem("name", layer));
+        e.setAttribute("type", "layer");
         
-        publishablesElem.addContent(elem("layer", elem("name", layer)));
+        publishablesElem.addContent(e);
         
         Element style = new Element("style");
         stylesElem.addContent(style);
         if (styleName != null) {
             style.addContent(elem("name", styleName));         
         }
+    }
+    
+    public void addLayerGroup(String layer) {
+        initPublishables("publishables");
+        Element e = elem("published", elem("name", layer));
+        e.setAttribute("type", "layerGroup"); 
+        
+        publishablesElem.addContent(e);
+        
+        Element style = new Element("style");
+        stylesElem.addContent(style);
     }
     
     public void setBounds(String crs, double minx, double maxx, double miny, double maxy) {


### PR DESCRIPTION
Actually, geoserver support layergroups nested in other layergroup, but geoserver-manager is not updated to support this feature. 
This patch would remove this gap. 

The xml is changed a little bit, replacing tag 'layers' with 'publishables' and 'layer' tag with 'published'.
After that, I added addLayerGroup method, cloned from addLayer.
