### PR TITLE
Pull Request for Issue #166

### DIFF
--- a/src/test/java/it/geosolutions/geoserver/rest/encoder/GSLayerEncoder21Test.java
+++ b/src/test/java/it/geosolutions/geoserver/rest/encoder/GSLayerEncoder21Test.java
@@ -20,6 +20,8 @@
 package it.geosolutions.geoserver.rest.encoder;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import it.geosolutions.geoserver.rest.encoder.authorityurl.AuthorityURLInfo;
@@ -101,6 +103,7 @@ public class GSLayerEncoder21Test {
 						jsonStr.length() - 3);
 
 				String[] items = jsonStr.split("\\}(,)\\{");
+				Arrays.sort(items, Collections.reverseOrder());
 
 				String[] props1 = items[0].split(",");
 				String[] kvp1_1 = props1[0].split("\":");


### PR DESCRIPTION
The test "GSLayerEncoder21Test.testMetadata" fails on Java 8. The url generated by GSLayerEncoder21 creates the JSON string by iterating through the elements of the identifierList HashMap. The iteration order of HashMap changed from Java 7 to Java 8. Here is a proposed fix that forces a fixed order of the items used in the test by sorting. The reverse order is used to preserve the existing order of assertions in the code. 

This fix resolves issue #166 