### PR TITLE
existsLayer overloading bug in GeoServerRESTReader

### DIFF
--- a/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTReader.java
+++ b/src/main/java/it/geosolutions/geoserver/rest/GeoServerRESTReader.java
@@ -903,7 +903,7 @@ public class GeoServerRESTReader {
      * @return boolean indicating if the Layer exists
      */
     public boolean existsLayer(String workspace, String name){
-        return existsLayerGroup(workspace, name, Util.DEFAULT_QUIET_ON_NOT_FOUND);
+        return existsLayer(workspace, name, Util.DEFAULT_QUIET_ON_NOT_FOUND);
     }
 
     //==========================================================================


### PR DESCRIPTION
Similar problem to https://github.com/geosolutions-it/geoserver-manager/pull/192.
In this case, existsLayer should call the overloaded existsLayer, but wrongly calls existsLayerGroup.
